### PR TITLE
Update awkit dependency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.0.2 (2020-04-30)
+==================
+
++ Updated awxkit version
+- Removed provider from host information
+
 0.0.1 (2020-04-28)
 ==================
 

--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -8,7 +8,6 @@ class Host:
             self.__dict__.update(kwargs)
         else:
             self.hostname = hostname
-            self.provider = kwargs.get("provider")
         self.session = self._get_session()
 
     def _get_session(self):
@@ -34,7 +33,6 @@ class Host:
     def to_dict(self):
         return {
             "hostname": self.hostname,
-            "provider": self.provider,
             "_broker_provider": self._broker_provider,
             "type": "host",
         }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 AWXKIT = (
     "awxkit @ git+ssh://git@github.com/ansible/awx"
-    "@11.1.0#egg=awxkit&subdirectory=awxkit"
+    "@11.2.0#egg=awxkit&subdirectory=awxkit"
 )
 
 from setuptools import setup, find_packages
@@ -16,12 +16,12 @@ requirements = [AWXKIT, "click", "dynaconf[yaml]", "logzero", "pyyaml"]
 
 setup(
     name="broker",
-    version="0.0.1",
+    version="0.0.2",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     author="Jacob J Callahan",
     author_email="jacob.callahan05@@gmail.com",
-    url="https://github.com/JacobCallahan/broker",
+    url="https://github.com/SatelliteQE/broker",
     packages=find_packages(),
     entry_points={"console_scripts": ["broker=broker.commands:cli"]},
     include_package_data=True,


### PR DESCRIPTION
This updated version of awxkit is now compatible with pip 20+

I also removed the provider information from the host, as we likely won't need this for a while.