### PR TITLE
Adding duplicate command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.0.3 (2020-04-30)
+==================
+
++ Introduced duplicate command
+  Note that this will not work with old inventory format
+
 0.0.2 (2020-04-30)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Broker is a tool designed to provide a common interface between one or many serv
 ```
 cd <broker root directory>
 pip install .
-mv setting.yaml.example settings.yaml
+cp setting.yaml.example settings.yaml
 ```
 Then edit the settings.yaml file
 
@@ -20,11 +20,23 @@ broker checkout --workflow "workflow-name" --workflow-arg1 something --workflow-
 You can pass in any arbitrary arguments you want
 
 **Nicks**
+
 Broker allows you to define configurable nicknames for checking out vms. Just add yours to setting.yaml and call with the ```--nick``` option
 ```
 broker checkout --nick rhel7
 ```
+
+**Duplicating a VM**
+
+Broker offers another shortcut for checking out a VM with the same recipe as one already checked out by Broker. This is via the ```duplicate``` command.
+```
+broker duplicate my.awesome.vm.com
+broker duplicate 0
+broker duplicate 1 3
+```
+
 **Listing your VMs**
+
 Broker maintains a local inventory of the VMs you've checked out. You can see these with the ```inventory``` command.
 ```
 broker inventory

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -7,6 +7,19 @@ from broker import logger as b_log
 from broker import helpers
 
 
+def _checkout(**broker_args):
+    """Internal function to provide a common checkout interface
+    This allows us to duplicate currently checked out systems
+    """
+    broker_inst = VMBroker(**broker_args)
+    broker_inst.checkout()
+    new_hosts = []
+    for host in broker_inst._hosts:
+        logger.info(f"{host.__class__.__name__}: {host.hostname}")
+        new_hosts.append(host.to_dict())
+    helpers.update_inventory(new_hosts)
+
+
 @click.group()
 @click.option("--debug", is_flag=True)
 def cli(debug):
@@ -30,20 +43,15 @@ def checkout(ctx, workflow, nick):
         broker_args = helpers.resolve_nick(nick)
     if workflow:
         broker_args["workflow"] = workflow
-    # if additional arguments were passes, include them in the broker args
+    # if additional arguments were passed, include them in the broker args
     broker_args.update(dict(zip(ctx.args[::2], ctx.args[1::2])))
-    broker_inst = VMBroker(**broker_args)
-    broker_inst.checkout()
-    new_hosts = []
-    for host in broker_inst._hosts:
-        logger.info(f"{host.__class__.__name__}: {host.hostname}")
-        new_hosts.append(host.to_dict())
-    helpers.update_inventory(new_hosts)
+    _checkout(**broker_args)
 
 
 @cli.command()
 @click.argument("vm", type=str, nargs=-1)
-def checkin(vm):
+@click.option("--all", "all_", is_flag=True, help="Select all VMs")
+def checkin(vm, all_):
     """Checkin a VM or series of VMs
 
     COMMAND: broker checkin <vm hostname>|<local id>|all
@@ -51,7 +59,7 @@ def checkin(vm):
     inventory = helpers.load_inventory()
     to_remove = []
     for num, host in enumerate(inventory):
-        if str(num) in vm or host["hostname"] in vm or "all" in vm:
+        if str(num) in vm or host["hostname"] in vm or all_:
             to_remove.append((num, host))
     # reconstruct the hosts and call their release methhod
     for num, host in to_remove[::-1]:
@@ -64,10 +72,31 @@ def checkin(vm):
 @click.option("--details", is_flag=True, help="Display all hist details")
 def inventory(details):
     """Get a list of all VMs you've checked out"""
-    logger.info("Pulling local ivnentory")
+    logger.info("Pulling local inventory")
     inventory = helpers.load_inventory()
     for num, host in enumerate(inventory):
         if details:
             logger.info(f"{num}: {host.pop('hostname')}, Details: {host}")
         else:
             logger.info(f"{num}: {host['hostname']}")
+
+
+@cli.command()
+@click.argument("vm", type=str, nargs=-1)
+@click.option("--all", "all_", is_flag=True, help="Select all VMs")
+def duplicate(vm, all_):
+    """Duplicate a broker-procured vm
+
+    COMMAND: broker duplicate <vm hostname>|<local id>|all
+    """
+    inventory = helpers.load_inventory()
+    for num, host in enumerate(inventory):
+        if str(num) in vm or host["hostname"] in vm or all_:
+            broker_args = host.get("_broker_args")
+            if broker_args:
+                logger.info(f"Duplicating: {host['hostname']}")
+                _checkout(**broker_args)
+            else:
+                logger.warning(
+                    f"Unable to duplicate {host['hostname']}, no _broker_args found"
+                )

--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -35,6 +35,7 @@ class Host:
             "hostname": self.hostname,
             "_broker_provider": self._broker_provider,
             "type": "host",
+            "_broker_args": self._broker_args
         }
 
     @classmethod

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -29,12 +29,13 @@ class AnsibleTower(Provider):
     def _host_release(self):
         self._at_inst.release(self)
 
-    def _set_attributes(self, host_inst):
+    def _set_attributes(self, host_inst, broker_args=None):
         host_inst.__dict__.update(
             {
                 "release": self._host_release,
                 "_at_inst": self,
                 "_broker_provider": "AnsibleTower",
+                "_broker_args": broker_args,
             }
         )
 
@@ -77,7 +78,7 @@ class AnsibleTower(Provider):
         logger.debug(f"hostname: {hostname}, host type: {host_type}")
         if hostname:
             host_inst = host_classes[host_type](hostname=hostname, **kwargs)
-            self._set_attributes(host_inst)
+            self._set_attributes(host_inst, broker_args=kwargs)
             return host_inst
         raise Exception(f"No hostname found in job attributes:\n{job_attrs}")
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [AWXKIT, "click", "dynaconf[yaml]", "logzero", "pyyaml"]
 
 setup(
     name="broker",
-    version="0.0.2",
+    version="0.0.3",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     author="Jacob J Callahan",


### PR DESCRIPTION
This allows us to duplicate the arguments used to checkout a
system in our current inventory.
Also fixed some typos.