### PR TITLE
Re-raise existing exception, not Exception

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -120,7 +120,7 @@ class VMBroker:
             return self.checkout(connect=True)
         except Exception as err:
             self.checkin()
-            raise Exception
+            raise err
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.checkin()


### PR DESCRIPTION
I haven't taken the time to read through all of the existing code and
understand what it does, but as a general matter, it's a bad idea to
raise `Exception`, especially when doing so suppresses some other
exception. If `Exception` really is desired, I'd recommend:

    raise Exception from err