### PR TITLE
Don't throw exception when child job object can't be accessed

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -72,8 +72,11 @@ class AnsibleTower(Provider):
             for child in children:
                 if child.type == "workflow_job_node":
                     child_id = child.summary_fields.job.id
-                    child_obj = self.v2.jobs.get(id=child_id).results.pop()
-                    artifacts = self._merge_artifacts(child_obj, strategy, artifacts)
+                    try:
+                        child_obj = self.v2.jobs.get(id=child_id).results.pop()
+                        artifacts = self._merge_artifacts(child_obj, strategy, artifacts)
+                    except IndexError:
+                        pass
         return artifacts
 
     def construct_host(self, provider_params, host_classes, **kwargs):


### PR DESCRIPTION
See #17 for discussion and details.
This way we might miss some "artifacts", but since I don't know what they are, I am not concerned about them.

```
$ broker checkout --workflow deploy-sat-lite --template satellite-6.8-latest
[INFO 200623 19:16:45] Using provider AnsibleTower to checkout
[INFO 200623 19:32:41] Host: dhcp-2-66.REDACTED.redhat.com
```