### PR TITLE
Update container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ MAINTAINER https://github.com/SatelliteQE
 RUN dnf -y install make cmake gcc-c++ zlib-devel \
            openssl-devel git python3-pip python3-devel \
            && dnf clean all
-WORKDIR /root/broker
-COPY . /root/broker/
+
+WORKDIR /home/broker
+COPY . /home/broker/
 RUN pip install .
 RUN cp settings.yaml.example settings.yaml
-
+RUN chmod -Rv 0777 /home/broker
+USER 1001
 
 ENTRYPOINT ["broker"]
 CMD ["--help"]


### PR DESCRIPTION
The current Docker image was being built as root. It is a security issue as well as not works well with OpenShift Pods. I am proposing to use `/home/broker` dir and make it `0777`. Also use `USER 1001` - an arbitrary user the container will use by default(this is just better way to build images based on my knowledge) - OpenShift will do random Username each time is creates container, so opening permissions to /home/broker will help us tackle issues about permissions. 