### PR TITLE
Wrap IndexError with log and exit condition

### DIFF
--- a/tests/data/ansible_tower/fake_workflows.json
+++ b/tests/data/ansible_tower/fake_workflows.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 34,
+    "type": "workflow_job_template",
+    "url": "/api/v2/workflow_job_templates/34/",
+    "name": "deploy-base-rhel"
+  }
+]


### PR DESCRIPTION
Handle the failure to find a workflow by name a little bit better, and log more information when executing workflows.

~~@JacobCallahan thoughts on the sys.exit call here? Would you rather a different pattern?~~

### Error Handling
This used to result in an IndexError and traceback dump, captured and logged without the trace.

```
setup@localhost:~/repos/broker (handle-workflow-indexerror*>) % broker execute  --workflow does-not-exist
[INFO 200707 14:18:28] Using provider AnsibleTower for execution
[ERROR 200707 14:18:29] Workflow not found by name: does-not-exist
[INFO 200707 14:18:29] None
```

### New Logging
Add logging for the workflow template URL and the job URL, so the user can more easily identify and track their request.

```
setup@localhost:~/repos/broker (handle-workflow-indexerror*>) % broker execute  --workflow workflow-broker-test
[INFO 200707 14:14:29] Using provider AnsibleTower for execution
[INFO 200707 14:14:31] Found workflow by name [workflow-broker-test] with description: I made this part up
[INFO 200707 14:14:31] Launching workflow template: https://<ansible-tower-url>/api/v2/workflow_job_templates/53/
[INFO 200707 14:14:31] Waiting for job: https://<ansible-tower-url>/api/v2/workflow_jobs/6455/
```