### PR TITLE
[Alternate]Add background mode to Broker cli

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.0.11 (2020-07-02)
+==================
+
++ Added background mode to broker's cli
++ Added log-level silent
+
 0.0.10 (2020-06-29)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You may use either the local id (```broker inventory```), the hostname, or "all"
 broker checkin my.host.fqdn.com
 broker checkin 0
 broker checkin 1 3 my.host.fqdn.com
-broker checkin all
+broker checkin --all
 ```
 
 **Creating nicks**
@@ -75,4 +75,14 @@ If a provider action doesn't result in a host creation/removal, Broker allows yo
 broker execute --help
 broker execute --workflow my-awesome-workflow --additional-arg True
 broker execute -o raw --workflow my-awesome-workflow --additional-arg True
+```
+
+**Run Broker in the background**
+Certain Broker actions can be run in the background, these currently are: checkout, checkin, duplicate, and execute. When running a command in this mode, it will spin up a new Broker process and no longer log to stderr. To check progress, you can still follow broker's log file.
+Note that background mode will interfere with output options for execute since it won't be able to print to stdout. Those should kept in log mode.
+```
+broker checkout --background --nick rhel7
+broker checkin -b --all
+broker duplicate -b 0
+broker execute -b --workflow my-awesome-workflow --artifacts
 ```

--- a/broker/logger.py
+++ b/broker/logger.py
@@ -7,7 +7,7 @@ import logzero
 from broker.settings import BROKER_DIRECTORY
 
 
-def setup_logzero(level="info", path="logs/broker.log"):
+def setup_logzero(level="info", path="logs/broker.log", silent=False):
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
     debug_fmt = (
         "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"
@@ -16,7 +16,7 @@ def setup_logzero(level="info", path="logs/broker.log"):
     log_level = getattr(logging, level.upper(), logging.INFO)
 
     formatter = logzero.LogFormatter(fmt=debug_fmt if log_level is logging.DEBUG else log_fmt)
-    logzero.setup_default_logger(formatter=formatter)
+    logzero.setup_default_logger(formatter=formatter, disableStderrLogger=silent)
     logzero.loglevel(log_level)
     path = str(BROKER_DIRECTORY.joinpath(path))
     logzero.logfile(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [AWXKIT, "click", "dynaconf>=3.0", "logzero", "pyyaml", "ssh2-pyt
 
 setup(
     name="broker",
-    version="0.0.10",
+    version="0.0.11",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     author="Jacob J Callahan",


### PR DESCRIPTION
This change introduces the ability for broker to spin up another broker
subprocess and exit.
This new broker subprocess will also have a new log-level of "silent".
A "silent" log level has a level of INFO, but only logs to broker's log file.