### PR TITLE
Bring your own host classes

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -122,7 +122,7 @@ def checkin(vm, background, all_):
     to_remove = []
     for num, host in enumerate(inventory):
         if str(num) in vm or host["hostname"] in vm or host["name"] in vm or all_:
-            to_remove.append(VMBroker.reconstruct_host(host))
+            to_remove.append(VMBroker().reconstruct_host(host))
     broker_inst = VMBroker(hosts=to_remove)
     broker_inst.checkin()
 
@@ -174,7 +174,7 @@ def extend(vm, background, all_):
     to_extend = []
     for num, host in enumerate(inventory):
         if str(num) in vm or host["hostname"] in vm or host["name"] in vm or all_:
-            to_extend.append(VMBroker.reconstruct_host(host))
+            to_extend.append(VMBroker().reconstruct_host(host))
     broker_inst = VMBroker(hosts=to_extend)
     broker_inst.extend()
 

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -73,15 +73,21 @@ class AnsibleTower(Provider):
                 artifacts = at_object.artifacts
         if "workflow_nodes" in at_object.related:
             children = at_object.get_related("workflow_nodes").results
+            children.sort(key=lambda child: child.summary_fields.job.id)
             for child in children:
                 if child.type == "workflow_job_node":
                     logger.debug(child)
                     child_id = child.summary_fields.job.id
                     child_obj = self.v2.jobs.get(id=child_id).results.pop()
                     if child_obj:
-                        artifacts = self._merge_artifacts(child_obj, strategy, artifacts) or artifacts
+                        artifacts = (
+                            self._merge_artifacts(child_obj, strategy, artifacts)
+                            or artifacts
+                        )
                     else:
-                        logger.warning(f"Unable to pull information from child job with id {child_id}.")
+                        logger.warning(
+                            f"Unable to pull information from child job with id {child_id}."
+                        )
         return artifacts
 
     def _compile_host_info(self, host):
@@ -99,9 +105,13 @@ class AnsibleTower(Provider):
                 if val and isinstance(val, str)
             }
             try:
-                broker_args["workflow"] = host.get_related("last_job").summary_fields.source_workflow_job.name
+                broker_args["workflow"] = host.get_related(
+                    "last_job"
+                ).summary_fields.source_workflow_job.name
             except:
-                logger.warning(f"Unable to determine workflow for {host_info['hostname']}")
+                logger.warning(
+                    f"Unable to determine workflow for {host_info['hostname']}"
+                )
             host_info["_broker_args"] = broker_args
         return host_info
 
@@ -154,11 +164,13 @@ class AnsibleTower(Provider):
         if wfjts:
             wfjt = wfjts.pop()
         else:
-            logger.error(f'Workflow not found by name: {workflow}')
+            logger.error(f"Workflow not found by name: {workflow}")
             return
-        logger.debug(f'Launching workflow template: {AT_URL}{wfjt.url}'.replace("//","/"))
+        logger.debug(
+            f"Launching workflow template: {AT_URL}{wfjt.url}".replace("//", "/")
+        )
         job = wfjt.launch(payload={"extra_vars": str(kwargs).replace("--", "")})
-        logger.info(f'Waiting for job: {AT_URL}{job.url}'.replace("//","/"))
+        logger.info(f"Waiting for job: {AT_URL}{job.url}".replace("//", "/"))
         job.wait_until_completed(timeout=1800)
         if not job.status == "successful":
             logger.error(
@@ -172,7 +184,11 @@ class AnsibleTower(Provider):
     def get_inventory(self, user=None):
         """Compile a list of hosts based on any inventory a user's name is mentioned"""
         user = user or UNAME
-        invs = [inv for inv in self.v2.inventory.get(page_size=100).results if user in inv.name]
+        invs = [
+            inv
+            for inv in self.v2.inventory.get(page_size=100).results
+            if user in inv.name
+        ]
         hosts = []
         for inv in invs:
             inv_hosts = inv.get_related("hosts").results

--- a/tests/providers/test_ansible_tower.py
+++ b/tests/providers/test_ansible_tower.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from broker.broker import HOST_CLASSES
+from broker.broker import VMBroker
 from broker.providers.ansible_tower import AnsibleTower
 from broker.helpers import MockStub
 
@@ -92,9 +92,10 @@ def test_exec_workflow(tower_stub):
 
 
 def test_host_creation(tower_stub):
+    vmb = VMBroker()
     job = tower_stub.exec_workflow(workflow="deploy-base-rhel")
-    host = tower_stub.construct_host(job, HOST_CLASSES)
-    assert isinstance(host, HOST_CLASSES["host"])
+    host = tower_stub.construct_host(job, vmb.host_classes)
+    assert isinstance(host, vmb.host_classes["host"])
     assert host.hostname == "fake.host.test.com"
 
 


### PR DESCRIPTION
This change adds the ability to override or supply your own
host classes via the VMBroker class.
VMBroker now looks for a kwarg called "host_classes" which should be
a dictionary mapping class name to the class object.