### PR TITLE
adding the property to see the vm host expire time

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import datetime
 from broker.settings import settings
 from logzero import logger
 
@@ -91,11 +92,16 @@ class AnsibleTower(Provider):
                         )
         return artifacts
 
+    def _get_expire_date(self, host_id):
+        time_stamp = self.v2.hosts.get(id=host_id).results[0].related.ansible_facts.get().expire_date
+        return str(datetime.datetime.fromtimestamp(int(time_stamp)))
+
     def _compile_host_info(self, host):
         host_info = {
             "name": host.name,
             "type": host.type,
             "hostname": host.variables["fqdn"],
+            "expire_time": self._get_expire_date(host.id),
             "_broker_provider": "AnsibleTower",
         }
         if "last_job" in host.related:


### PR DESCRIPTION
### PR Details
Adding expire time property for details command, this will require sync and needs cleaning of the inventory file. 

### Result 

```
(env) [root@okhatavk broker]# broker inventory --details 
[INFO 200807 20:08:12] Pulling local inventory
[INFO 200807 20:08:12] 0: hostname_1.redhat.com, Details: _broker_args:
      host_type: satellite
      provider: RHEV
      rhel_version: '7.7'
      template: satellite-6.8.0-10.0
      workflow: deploy-sat-lite
    _broker_provider: AnsibleTower
    expire_time: '2020-08-10 15:31:28'
    hostname: hostname_1.redhat.com
    name: okhatavk-satellite-6.8.0-10.0-1596793936
    type: host
    
```