### PR TITLE
Use token authentication for Tower

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Broker can also be ran outside of its base directory. In order to do so, specify
 `BROKER_DIRECTORY` envronment variable.
 ```BROKER_DIRECTORY=/home/jake/Programming/broker/ broker inventory```
 
+# Configuration
+The broker_settings.yaml file is used, through DynaConf, to set configuration values for broker's interaction with its 'providers'.
+
+DynaConf integration provides support for setting environment variables to override any settings from the yaml file.
+
+An environment variable override would take the form of: `DYNACONF_AnsibleTower__base_url="https://my.ansibletower.instance.com"`. Note the use of double underscores to model nested maps in yaml.
+
+For the AnsibleTower provider, authentication can be achieved either through setting a username and password, or through a token (Personal Access Token in Tower).
+
+A username can still be provided when using a token to authenticate. This user will be used for inventory sync (examples below). This may be helpful for AnsibleTower administrators who would like to use their own token to authenticate, but want to set a different user in configuration for checking inventory.
+
 # Usage
 **Checking out a VM**
 ```
@@ -53,6 +64,10 @@ broker inventory
 To sync your inventory from a supported provider, use the `--sync` option.
 ```
 broker inventory --sync AnsibleTower
+```
+To sync inventory for a specific user, use the following syntax with `--sync`.
+```
+broker inventory --sync AnsibleTower:<username>
 ```
 
 **Extending your VM lease time***

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -16,8 +16,6 @@ if "BROKER_DIRECTORY" in os.environ:
 settings_path = BROKER_DIRECTORY.joinpath("broker_settings.yaml")
 must_exist = [
     "ANSIBLETOWER.base_url",
-    "ANSIBLETOWER.username",
-    "ANSIBLETOWER.password",
     "NICKS",
     "HOST_PASSWORD",
 ]
@@ -27,8 +25,12 @@ validators = [
     Validator("ANSIBLETOWER.extend_workflow", default="extend-vm"),
     Validator("ANSIBLETOWER.workflow_timeout", is_type_of=int, default=3600),
     Validator("HOST_USERNAME", default="root"),
+    # Validator combination for username+password or token
+    ((Validator("ANSIBLETOWER.username", must_exist=True) & Validator("ANSIBLETOWER.password", must_exist=True))
+        | Validator("ANSIBLETOWER.token", must_exist=True))
 ]
 settings = Dynaconf(settings_file=str(settings_path), validators=validators,)
+
 try:
     settings.validators.validate()
 except ValidationError as err:

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -7,8 +7,10 @@ host_password: "<password>"
 # Provider settings
 AnsibleTower:
     base_url: "https://<ansible tower host>/"
+    # Username AND password, OR an OAUTH token can be used for authentication
     username: "<username>"
     password: "<plain text password>"
+    token: "<AT personal access token>"
     release_workflow: "remove-vm"
     extend_workflow: "extend-vm"
     workflow_timeout: 3600


### PR DESCRIPTION
Support token authentication for AnsibleTower provider.

On the tower side, this requires an Application, which the tokens are registered under, and a global setting to allow token creation for OAuth users.

When using token, username and password settings are no longer necessary.