### PR TITLE
Make broker more resilient to running outside its directory

### DIFF
--- a/broker/logger.py
+++ b/broker/logger.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 """Module handling internal and dependency logging."""
-import os
 import logging
 from pathlib import Path
 import logzero
@@ -8,6 +7,8 @@ from broker.settings import BROKER_DIRECTORY
 
 
 def setup_logzero(level="info", path="logs/broker.log", silent=False):
+    path = str(BROKER_DIRECTORY.joinpath(path))
+    path.parent.mkdir(parents=True, exist_ok=True)
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
     debug_fmt = (
         "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"
@@ -18,7 +19,6 @@ def setup_logzero(level="info", path="logs/broker.log", silent=False):
     formatter = logzero.LogFormatter(fmt=debug_fmt if log_level is logging.DEBUG else log_fmt)
     logzero.setup_default_logger(formatter=formatter, disableStderrLogger=silent)
     logzero.loglevel(log_level)
-    path = str(BROKER_DIRECTORY.joinpath(path))
     logzero.logfile(
         path, loglevel=log_level, maxBytes=1e9, backupCount=3, formatter=formatter
     )


### PR DESCRIPTION
This change will now create the logs directory if it doesn't exist
at BROKER_DIRECTORY. This makes it so the BROKER_DIRECTORY doesn't
have to be broker's root directory.