### PR TITLE
Removing validator for NICKS as it shouldn't be mandatory

### DIFF
--- a/broker/settings.py
+++ b/broker/settings.py
@@ -16,7 +16,6 @@ if "BROKER_DIRECTORY" in os.environ:
 settings_path = BROKER_DIRECTORY.joinpath("broker_settings.yaml")
 must_exist = [
     "ANSIBLETOWER.base_url",
-    "NICKS",
     "HOST_PASSWORD",
 ]
 validators = [


### PR DESCRIPTION
- Nicks are not always used by everyone, for example, in my current jenkins implementation I don't have need for NICKS and broker fails, hence removing the validation. 