### PR TITLE
Update tower logging to provide UI URLs

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import sys
+from urllib import parse as url_parser
 from broker.settings import settings
 from logzero import logger
 from datetime import datetime
@@ -210,11 +211,11 @@ class AnsibleTower(Provider):
         else:
             logger.error(f"Workflow not found by name: {workflow}")
             return
-        logger.debug(
-            f"Launching workflow template: {AT_URL}{wfjt.url}".replace("//", "/")
-        )
+        logger.debug(f"Launching workflow template: {url_parser.urljoin(AT_URL, str(wfjt.url))}")
         job = wfjt.launch(payload={"extra_vars": str(kwargs).replace("--", "")})
-        logger.info(f"Waiting for job: {AT_URL}{job.url}".replace("//", "/"))
+        job_number = job.url.rstrip("/").split("/")[-1]
+        job_ui_url = url_parser.urljoin(AT_URL, f"/#/workflows/{job_number}")
+        logger.info(f"Waiting for job: \nAPI: {url_parser.urljoin(AT_URL, str(job.url))}\nUI: {job_ui_url}")
         job.wait_until_completed(timeout=AT_TIMEOUT)
         if not job.status == "successful":
             logger.error(

--- a/tests/data/ansible_tower/fake_jobs.json
+++ b/tests/data/ansible_tower/fake_jobs.json
@@ -6,7 +6,8 @@
             "workflow_nodes": "/api/v2/workflow_jobs/343/workflow_nodes/"
         },
         "name": "deploy-base-rhel",
-        "status": "successful"
+        "status": "successful",
+        "url": "/api/v2/workflow_jobs/1329/"
     },
     {
         "id": 1337,


### PR DESCRIPTION
UI urls are a bit more user friendly

Use urllib.parse instead of mangling strings for URLs

Before, logged URLS had `http:/<host>/<path>`, which on console isn't parsed as a URI, and can't be directly clicked/linked. This was due to using `.replace()` to resolve any double slashes from the host ending with a slash and the path starting with a slash.

Output now looks like:
```
[INFO 200915 08:07:43] Using provider AnsibleTower to checkout
[INFO 200915 08:07:43] Using username and password authentication
[INFO 200915 08:07:45] Waiting for job: 
    API: https://<host>/api/v2/workflow_jobs/1363/
    UI: https://<host>/#/workflows/1363
```