### PR TITLE
nick-help command now changed to providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ install: pip install .
 script:
     - mv broker_settings.yaml.example broker_settings.yaml
     - pytest -v
+deploy:
+    provider: pypi
+    user: jacobcallahan
+    password:
+        secure: ZUdoUV4c1AK7I1zVSk2CF2y2jzBxc4PRNvYtWrhdZFwFYF3TiyUCssUu0PC0V1OZo57rg/Y4TkhoQ6KnXQqaOlY8d+qGoL3Id4Oigv9sYB7cuIDPOviFag1Qw3lCAM2lflrMNHBFklZCR2xS7TddpwMEG1PTEuKQfYwdYV19oaViaJtYkcXiHoKA6triA6EtzsYq+tmFcJ0tiugV9NYAgqhQp+int0ZYzB0quZHgd/yTAIUH9Gf0QI+vKku0ymfAXHC+JlEqd8RuANgwkNFxVJkkxxX3QaBRtL7J8zYJY9k67LfIQUeiH6tQJYUGunHRRER3DXqEk5sPr+cMpJi3YZhxUBXJc6ss2dqKu47MRyDtJabPvbGHKdjt02+YLIXehzhKctKrtX640uBKRBwTGr2jwiDHyj3r1n/gdS0MqkMm2wB96Lb2RV17wy9xh4zIy2YZw1y41plX9o64cnQqJt9QVhjW0w4Efihkw/ylVEVgfEo6nOlVZ/fOmERxrGeLdwPaESpV1L6lViVJCawFiWKAocMaZ6s5WtHpUyeb2dxHwf56mnGKMiOfvqgs5/a6Wmhm1ad/hvjHPxjT9HxImv4YYwJnIxLdwuO1MPBIfqlWVfsP6d8LoDvHLYp+dbKItohvZVfDJVAU7vpYcyaCVzSwFxM6P5ox0WgBL1Wt++E=
+    on:
+        branch: master
+        repo: SatelliteQE/broker
+    skip_existing: true

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.1.2 (2020-09-17)
+==================
+
++ nick-help command changed to providers
++ providers command is now dynamically populated
++ Fixes for logging
++ Now more resilient to running outside of broker's directory
+
 0.1.1 (2020-09-02)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,14 @@ broker checkin 1 3 my.host.fqdn.com
 broker checkin --all
 ```
 
-**Creating nicks**
+**Gaining information about Broker's providers**
 
-Broker will attempt to help your create your own nicks with the ```nick-help``` command.
-If supported by your chosen provider, nick-help will display the additional arguments you can use when defining a new nick.
+Broker's `providers` command allows you to gather information about what providers are avaiable as well as each providers actions. Additionally, you can find out information about different arguments for a provider's action with this command.
 ```
-broker nick-help --help
-broker nick-help --workflow my-awesome-workflow
-```
-Additionally, if you're unfamiliar with what actions are supported by your provider, you can get a list by passing the provider's name.
-```
-broker nick-help --provider AnsibleTower
+broker providers --help
+broker providers AnsibleTower --help
+broker providers AnsibleTower --workflows
+broker providers AnsibleTower --workflow remove-vm
 ```
 
 **Run arbitrary actions**

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python
-AWXKIT = (
-    "awxkit @ git+https://github.com/ansible/awx.git"
-    "@14.1.0#egg=awxkit&subdirectory=awxkit"
-)
-
 from setuptools import setup, find_packages
 
 with open("README.md") as readme_file:
@@ -12,15 +7,16 @@ with open("README.md") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = [AWXKIT, "click", "dynaconf>=3.1", "logzero", "pyyaml", "ssh2-python"]
+requirements = ["awxkit", "click", "dynaconf>=3.1.0", "logzero", "pyyaml", "ssh2-python"]
 
 setup(
     name="broker",
-    version="0.1.1",
+    version="0.1.2",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
+    long_description_content_type="text/markdown",
     author="Jacob J Callahan",
-    author_email="jacob.callahan05@@gmail.com",
+    author_email="jacob.callahan05@gmail.com",
     url="https://github.com/SatelliteQE/broker",
     packages=find_packages(),
     entry_points={"console_scripts": ["broker=broker.commands:cli"]},
@@ -30,7 +26,7 @@ setup(
     zip_safe=False,
     keywords="broker",
     classifiers=[
-        "Development Status :: 2 - Beta",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Natural Language :: English",


### PR DESCRIPTION
This change now allows a cli user to gain more information about
what they can do with broker and its providers.
The new providers command is dynamically generated from information,
about providers and their actions, stored in broker.py

fixes #41