### PR TITLE
Make the settings example have token commented out

### DIFF
--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -10,7 +10,7 @@ AnsibleTower:
     # Username AND password, OR an OAUTH token can be used for authentication
     username: "<username>"
     password: "<plain text password>"
-    token: "<AT personal access token>"
+    # token: "<AT personal access token>"
     release_workflow: "remove-vm"
     extend_workflow: "extend-vm"
     workflow_timeout: 3600


### PR DESCRIPTION
If a user copies the example and only sets username/password, like they're likely to with envvars, token will override their envvar use
Keep the default behavior on copying broker_settings.yaml.example as simple as possible, changing as few values as possible for a clean configuration