### PR TITLE
Use concurrent.futures to fix multiprocessing issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install: pip install .[test]
 script:
     - cp broker_settings.yaml.example broker_settings.yaml
-    - pytest -v
+    - pytest -v tests
 deploy:
     provider: pypi
     user: jacobcallahan

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 language: python
 python:
     - "3.8"
-install: pip install .
+install: pip install .[test]
 script:
     - cp broker_settings.yaml.example broker_settings.yaml
     - pytest -v

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -37,7 +37,7 @@ class mp_decorator:
 
     MAX_WORKERS = None
     """ If set to integer, the count of workers will be limited to that amount.
-     If set to None, the max workers count of the EXECUTOR will be matching the count of items."""
+     If set to None, the max workers count of the EXECUTOR will match the count of items."""
 
     EXECUTOR = ProcessPoolExecutor
 
@@ -54,7 +54,7 @@ class mp_decorator:
                 return self.func(instance, *args, **kwargs)
 
             results = []
-            max_workers_count = count if self.MAX_WORKERS is None else self.MAX_WORKERS
+            max_workers_count = self.MAX_WORKERS or count
             with self.EXECUTOR(max_workers=max_workers_count) as workers:
                 completed_futures = as_completed(workers.submit(self.func, instance, *args, **kwargs)
                                                  for _ in range(count))

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -113,7 +113,6 @@ class VMBroker:
                     host.connect()
                 hosts.append(host)
                 logger.info(f"{host.__class__.__name__}: {host.hostname}")
-                helpers.update_inventory(add=host.to_dict())
         return hosts
 
     def checkout(self, connect=False):
@@ -125,6 +124,7 @@ class VMBroker:
         """
         hosts = self._checkout(connect=connect)
         self._hosts.extend(hosts)
+        helpers.update_inventory([host.to_dict() for host in hosts])
         return hosts if not len(hosts) == 1 else hosts[0]
 
     def execute(self, **kwargs):

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -35,7 +35,10 @@ class mp_decorator:
     # concurrent.futures. I got errors like:
     # _pickle.PicklingError: Can't pickle ... it's not the same object as ...
 
-    MAX_WORKERS = 5
+    MAX_WORKERS = None
+    """ If set to integer, the count of workers will be limited to that amount.
+     If set to None, the max workers count of the EXECUTOR will be matching the count of items."""
+
     EXECUTOR = ProcessPoolExecutor
 
     def __init__(self, func=None):
@@ -51,7 +54,8 @@ class mp_decorator:
                 return self.func(instance, *args, **kwargs)
 
             results = []
-            with self.EXECUTOR(max_workers=self.MAX_WORKERS) as workers:
+            max_workers_count = count if self.MAX_WORKERS is None else self.MAX_WORKERS
+            with self.EXECUTOR(max_workers=max_workers_count) as workers:
                 completed_futures = as_completed(workers.submit(self.func, instance, *args, **kwargs)
                                                  for _ in range(count))
                 for f in completed_futures:

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -4,7 +4,6 @@ from broker.providers.test_provider import TestProvider
 from broker.hosts import Host
 from broker import helpers
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import Type
 
 
 PROVIDERS = {"AnsibleTower": AnsibleTower, "TestProvider": TestProvider}
@@ -39,10 +38,10 @@ class mp_decorator:
     MAX_WORKERS = 5
     EXECUTOR = ProcessPoolExecutor
 
-    def __init__(self, func: callable = None):
+    def __init__(self, func=None):
         self.func = func
 
-    def __get__(self, instance: 'VMBroker', owner: Type['VMBroker']):
+    def __get__(self, instance, owner):
         if not instance:
             return self.func
 

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -107,7 +107,7 @@ class VMBroker:
             provider, method = PROVIDER_ACTIONS[action]
             logger.info(f"Using provider {provider.__name__} to checkout")
             host = self._act(provider, method, checkout=True)
-            logger.debug(f"{host=} {connect=}")
+            logger.debug(f"host={host} connect={connect}")
             if host:
                 if connect:
                     host.connect()

--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -1,7 +1,5 @@
 import inspect
 from broker.settings import settings
-from logzero import logger
-
 from broker.providers import Provider
 
 
@@ -38,7 +36,8 @@ class TestProvider(Provider):
     def construct_host(self, provider_params, host_classes, **kwargs):
         host_params = provider_params.copy()
         host_params.update(kwargs)
-        host_inst = host_classes[host_params["host_type"]](**host_params)
+        host_type = host_classes[host_params["host_type"]]
+        host_inst = host_type(**host_params)
         self._set_attributes(host_inst, broker_args=kwargs)
         return host_inst
 

--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -36,8 +36,7 @@ class TestProvider(Provider):
     def construct_host(self, provider_params, host_classes, **kwargs):
         host_params = provider_params.copy()
         host_params.update(kwargs)
-        host_type = host_classes[host_params["host_type"]]
-        host_inst = host_type(**host_params)
+        host_inst = host_classes[host_params["host_type"]](**host_params)
         self._set_attributes(host_inst, broker_args=kwargs)
         return host_inst
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,12 @@ with open("HISTORY.md") as history_file:
 
 requirements = ["awxkit", "click", "dynaconf>=3.1.0", "logzero", "pyyaml", "ssh2-python"]
 
+test_requirements = ['pytest']
+
+extras = {
+    'test': test_requirements,
+}
+
 setup(
     name="broker",
     version="0.1.3",
@@ -22,6 +28,8 @@ setup(
     entry_points={"console_scripts": ["broker=broker.commands:cli"]},
     include_package_data=True,
     install_requires=requirements,
+    test_requirements=test_requirements,
+    extras_require=extras,
     license="GNU General Public License v3",
     zip_safe=False,
     keywords="broker",

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -68,15 +68,16 @@ def test_mp_checkout_twice():
     cycle()
 
 
+class SomeException(Exception):
+    pass
+
+
 def test_mp_checkout_exc():
     broker_inst = broker.VMBroker(nick="test_nick", _count=2)
 
-    class SomeException(Exception):
-        pass
-
     # Note we are setting this on instance, not a class. There is no need to cleanup as the whole
     # broker is thrown away.
-    mock = broker_inst._act = MagicMock()
+    mock = broker.VMBroker._act = MagicMock()
     mock.side_effect = SomeException()
 
     with pytest.raises(SomeException):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,5 +1,7 @@
 from broker import broker
 from broker.providers import test_provider
+from unittest.mock import MagicMock
+import pytest
 
 
 def test_empty_init():
@@ -64,3 +66,18 @@ def test_mp_checkout_twice():
 
     cycle()
     cycle()
+
+
+def test_mp_checkout_exc():
+    broker_inst = broker.VMBroker(nick="test_nick", _count=2)
+
+    class SomeException(Exception):
+        pass
+
+    # Note we are setting this on instance, not a class. There is no need to cleanup as the whole
+    # broker is thrown away.
+    mock = broker_inst._act = MagicMock()
+    mock.side_effect = SomeException()
+
+    with pytest.raises(SomeException):
+        broker_inst.checkout()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -42,9 +42,25 @@ def test_broker_e2e():
     broker_inst.checkin()
     assert len(broker_inst._hosts) == 0
 
+
 def test_mp_checkout():
     """Test that broker can checkout multiple hosts using multiprocessing"""
     broker_inst = broker.VMBroker(nick="test_nick", _count=2)
     broker_inst.checkout()
     assert len(broker_inst._hosts) == 2
     broker_inst.checkin()
+    assert len(broker_inst._hosts) == 0
+
+
+def test_mp_checkout_twice():
+    broker_inst = broker.VMBroker(nick="test_nick", _count=2)
+
+    def cycle():
+        assert len(broker_inst.checkout()) == 2
+        assert len(broker_inst._hosts) == 2
+
+        broker_inst.checkin()
+        assert len(broker_inst._hosts) == 0
+
+    cycle()
+    cycle()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -46,9 +46,14 @@ def test_broker_e2e():
 
 def test_mp_checkout():
     """Test that broker can checkout multiple hosts using multiprocessing"""
-    broker_inst = broker.VMBroker(nick="test_nick", _count=2)
+    VM_COUNT=50  # This is intentionaly made high to catch run condition that
+                 # was discovered when reviewing
+                 # https://github.com/SatelliteQE/broker/pull/53
+                 # With count like this, I've got reproducibility probability
+                 # arround 0.5
+    broker_inst = broker.VMBroker(nick="test_nick", _count=VM_COUNT)
     broker_inst.checkout()
-    assert len(broker_inst._hosts) == 2
+    assert len(broker_inst._hosts) == VM_COUNT
     broker_inst.checkin()
     assert len(broker_inst._hosts) == 0
 


### PR DESCRIPTION
This makes the behavior of broker in case of exception rised in the child much better (without this PR, there is a deadlock and possible no output on the terminal about the exception. With this PR the exception is propagated to the parent process.

There were issues that I think were arising from using a decorator that replaced the decorated method with some nested method (the `wraps` function is commonly used in that case). It seems to me such method cannot be pickled but that seemed necessary for sending it to the `concurrent.futures`