### PR TITLE
Fix pickling, enable test_mp_checkout

### DIFF
--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -17,8 +17,25 @@ HOST_PROPERTIES = {
 
 class TestProvider(Provider):
     def __init__(self, **kwargs):
-        self.config = settings.TESTPROVIDER
+        # self.config = settings.TESTPROVIDER
+
+        # Enabling the line above leads to problems to pickle in
+        # tests/test_broker.py::test_mp_checkout
+        # that resulted in deadlock. This was quite hard to find problem as the tracebacks and
+        # errors I was getting were not helpful:
+        # Traceback (most recent call last):
+        #   File "/usr/lib64/python3.9/multiprocessing/queues.py", line 245, in _feed
+        #     obj = _ForkingPickler.dumps(obj)
+        #   File "/usr/lib64/python3.9/multiprocessing/reduction.py", line 51, in dumps
+        #     cls(buf, protocol).dump(obj)
+        # TypeError: cannot pickle 'module' object
+        #
+        # The root cause was tracked down with help of
+        # https://stackoverflow.com/a/59832602/1950100
+
+
         # self.__dict__.update(kwargs)
+        pass
 
     def _host_release(self):
         caller_host = inspect.stack()[1][0].f_locals["host"]

--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -17,25 +17,9 @@ HOST_PROPERTIES = {
 
 class TestProvider(Provider):
     def __init__(self, **kwargs):
-        # self.config = settings.TESTPROVIDER
-
-        # Enabling the line above leads to problems to pickle in
-        # tests/test_broker.py::test_mp_checkout
-        # that resulted in deadlock. This was quite hard to find problem as the tracebacks and
-        # errors I was getting were not helpful:
-        # Traceback (most recent call last):
-        #   File "/usr/lib64/python3.9/multiprocessing/queues.py", line 245, in _feed
-        #     obj = _ForkingPickler.dumps(obj)
-        #   File "/usr/lib64/python3.9/multiprocessing/reduction.py", line 51, in dumps
-        #     cls(buf, protocol).dump(obj)
-        # TypeError: cannot pickle 'module' object
-        #
-        # The root cause was tracked down with help of
-        # https://stackoverflow.com/a/59832602/1950100
-
+        self.config = settings.TESTPROVIDER.config_value
 
         # self.__dict__.update(kwargs)
-        pass
 
     def _host_release(self):
         caller_host = inspect.stack()[1][0].f_locals["host"]

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -42,11 +42,9 @@ def test_broker_e2e():
     broker_inst.checkin()
     assert len(broker_inst._hosts) == 0
 
-# Deprecated for now, as I'm unsure why this is failing
-# This functionality works with AnsibleTower
-# def test_mp_checkout():
-#     """Test that broker can checkout multiple hosts using multiprocessing"""
-#     broker_inst = broker.VMBroker(nick="test_nick", _count=2)
-#     broker_inst.checkout()
-#     assert len(broker_inst._hosts) == 2
-#     broker_inst.checkin()
+def test_mp_checkout():
+    """Test that broker can checkout multiple hosts using multiprocessing"""
+    broker_inst = broker.VMBroker(nick="test_nick", _count=2)
+    broker_inst.checkout()
+    assert len(broker_inst._hosts) == 2
+    broker_inst.checkin()


### PR DESCRIPTION
Pickling of an attribute in test_provider led to deadlock in the test. The whole module was used which is not picklable. The pickling is required for the `Queue.put`

Fixes #44

The PR #53 makes the error reporting much better.