### PR TITLE
Make TestProvider hidden instead of "not-loading it".

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -41,10 +41,10 @@ def populate_providers(click_group):
         --help           Show this message and exit.
     """
     for prov, prov_class in (
-        pairs for pairs in PROVIDERS.items() if pairs[0] != "TestProvider"
+        pairs for pairs in PROVIDERS.items()
     ):
 
-        @click_group.command(name=prov)
+        @click_group.command(name=prov, hidden=prov_class.hidden)
         def provider_cmd(*args, **kwargs):  # the actual subcommand
             """Get information about a provider's actions"""
             broker_inst = VMBroker(**kwargs)

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -2,6 +2,8 @@ import inspect
 
 
 class Provider:
+    hidden = False
+
     def __init__(self):
         self._construct_params = []
 

--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -14,7 +14,8 @@ HOST_PROPERTIES = {
 
 
 class TestProvider(Provider):
-    __test__ = False
+    __test__ = False  # don't use for testing
+    hidden = True  # hide from click command generation
 
     def __init__(self, **kwargs):
         self.config = settings.TESTPROVIDER.config_value


### PR DESCRIPTION
It seems to me the TestProvider it is not just filtered from listing the providers:
```
$ broker providers 
Usage: broker providers [OPTIONS] COMMAND [ARGS]...

  Get information about a provider and its actions

Options:
  --help  Show this message and exit.

Commands:
  AnsibleTower  Get information about a provider's actions
$ broker providers AnsibleTower
[INFO 201013 13:41:13] Querying provider AnsibleTower
[INFO 201013 13:41:13] Using username and password authentication
```

As AnsibleTower can be used, but TestProvider cannot:
```
$ broker providers TestProvider
Usage: broker providers [OPTIONS] COMMAND [ARGS]...
Try 'broker providers --help' for help.

Error: No such command 'TestProvider'.
```

Therefore I conclude the TestProvider cannot be used from CLI without manually changing the code in *commands.py*.

But it can be used with checkout command if this is in the *broker_settings.yaml*
```
nicks:
    test_nick:
        test_action: "fake"
        arg1: "abc"
        arg2: 123
        arg3: True
```

```
$ broker checkout -n test_nick
[INFO 201013 14:05:54] Using provider TestProvider to checkout
[INFO 201013 14:05:54] Host: test.host.example.com
```

The https://click.palletsprojects.com/en/7.x/api/?highlight=hidden#click.Option allows to hide the command from the click listing which I think is what is better to do if we want keep this TestProvider in CLI.