### PR TITLE
Fix broker version command

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -62,12 +62,12 @@ def populate_providers(click_group):
             provider_cmd = click.option(
                 f"--{action}", type=str, help=f"Get information about a {action}"
             )(provider_cmd)
-            provider_cmd = click.option(
-                f"--results-limit", type=int, help=f"The maximum number of results to get back"
-            )(provider_cmd)
-            provider_cmd = click.option(
-                f"--results-filter", type=str, help=f"Apply a broker filter to returned results"
-            )(provider_cmd)
+        provider_cmd = click.option(
+            f"--results-limit", type=int, help=f"The maximum number of results to get back"
+        )(provider_cmd)
+        provider_cmd = click.option(
+            f"--results-filter", type=str, help=f"Apply a broker filter to returned results"
+        )(provider_cmd)
 
 
 @click.group(invoke_without_command=True)
@@ -86,10 +86,9 @@ def populate_providers(click_group):
 )
 def cli(version):
     if version:
-        with open("setup.py") as setup_file:
-            for line in setup_file:
-                if "version" in line:
-                    click.echo(f"""Version: {line.split('"')[1]}""")
+        import pkg_resources
+        broker_version = pkg_resources.get_distribution("broker").version
+        click.echo(f"Version: {broker_version}")
         broker_directory = settings.BROKER_DIRECTORY.absolute()
         click.echo(f"Broker Directory: {broker_directory}")
         click.echo(f"Settings File: {settings.settings_path.absolute()}")

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -205,7 +205,7 @@ class AnsibleTower(Provider):
             for key, value in job_attrs.items():
                 if key.endswith("fqdn") and not hostname:
                     hostname = value if not isinstance(value, list) else value[0]
-                if key == "vm_provisioned" and not name:
+                if key in ("name", "vm_provisioned") and not name:
                     name = value if not isinstance(value, list) else value[0]
                 if key.endswith("host_type"):
                     host_type = value if value in host_classes else host_type
@@ -293,12 +293,13 @@ class AnsibleTower(Provider):
             workflows = "\n".join(workflows[:results_limit])
             logger.info(f"Available workflows:\n{workflows}")
         elif kwargs.get("templates"):
-            templates = [
+            templates = list({
                 tmpl
                 for tmpl in self.exec_workflow(
                     workflow="list-templates", artifacts="last"
                 )["data_out"]["list_templates"]
-            ]
+            })
+            templates.sort(reverse=True)
             if (res_filter := kwargs.get("results_filter")) :
                 templates = results_filter(templates, res_filter)
             templates = "\n".join(templates[:results_limit])


### PR DESCRIPTION
It currently reads from a relative setup.py file
New change doesn't rely on setup.py
Also small changes to providers generated help, removing duplicated limit and filter entires
Removed duplicates from --list-templates and reverse sorted ("higher" versions first)