### PR TITLE
hiding more details about the expired / SLA hit hosts

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -183,7 +183,10 @@ def checkin(vm, background, all_, filter):
 @click.option(
     "--filter", type=str, help="Display only what matches the specified filter"
 )
-def inventory(details, sync, filter):
+@click.option(
+    "--oneline", is_flag=True, help="Display host inventory in shorter format "
+)
+def inventory(details, sync, filter, oneline):
     """Get a list of all VMs you've checked out showing hostname and local id
     hostname pulled from list of dictionaries
     """
@@ -192,10 +195,24 @@ def inventory(details, sync, filter):
     logger.info("Pulling local inventory")
     inventory = helpers.load_inventory(filter=filter)
     for num, host in enumerate(inventory):
-        if details:
-            logger.info(
-                f"{num}: {host['hostname'] or host['name']}, Details: {helpers.yaml_format(host)}"
-            )
+        if oneline:
+            if host['hostname']:
+                logger.info(
+                    f"{num}: {host['hostname']} | {host['name']} "
+                )
+            else:
+                logger.info(
+                    f"{num}: {host['name']} is shutdown "
+                )
+        elif details:
+            if host['hostname']:
+                logger.info(
+                    f"{num}: {host['hostname'] or host['name']}, Details: {helpers.yaml_format(host)}"
+                )
+            else:
+                logger.info(
+                    f"{num}: {host['name']} is shutdown "
+                )
         else:
             logger.info(f"{num}: {host['hostname'] or host['name']}")
 


### PR DESCRIPTION
### PR Details 
I was locally using the broker, never liked to see the details of a NULL hostname which is hit it's SLA mainly shutdown. I thought way not hide those details and only keep the name which is used to restart the machine.

### Result

1. with hiding details
```
(env) /home/okhatavk/Satellite/broker (oneline_mode_refactor) $ broker inventory --details
[INFO 201123 17:05:14] Pulling local inventory
[INFO 201123 17:05:14] 0: example-sat-lite-6.8.0-20.0- is shutdown 
[INFO 201123 17:05:14] 1: example-sat-lite-6.8.0-20.0- is shutdown 
[INFO 201123 17:05:14] 2: example-sat-lite-6.9.0-2.0- is shutdown 
[INFO 201123 17:05:14] 3: satellite.example.com, Details: _broker_args:
      deploy_template_name: example-6.9.0-2.0-rhel-7
      workflow: example
    _broker_provider: AnsibleTower
    hostname: satellite.example.com
    name: example-sat-lite-6.9.0-2.0-
    type: host

```

2. with oneline output 

```
(env) /home/okhatavk/Satellite/broker (oneline_mode_refactor) $ broker inventory --oneline
[INFO 201123 17:08:31] Pulling local inventory
[INFO 201123 17:08:31] 0: example-sat-lite-6.8.0-20.0- is shutdown 
[INFO 201123 17:08:31] 1: example-sat-lite-6.8.0-20.0- is shutdown 
[INFO 201123 17:08:31] 2: example-sat-lite-6.9.0-2.0- is shutdown 
[INFO 201123 17:08:31] 3: satellite.example.com | example-sat-lite-6.9.0-2.0- 

```

    