### PR TITLE
Populate missing field values based on returned results from Ansible …

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+0.1.6 (2020-12-08)
+------------------
+
++ Broker now poulates missing field values based on returned results from AnsibleTower
++ AnsibleTower's artifacts strategy has been changed from merge to latest by default
+
 0.1.5 (2020-10-31)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
 
 setup(
     name="broker",
-    version="0.1.5",
+    version="0.1.6",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/data/ansible_tower/fake_jobs.json
+++ b/tests/data/ansible_tower/fake_jobs.json
@@ -7,7 +7,8 @@
         },
         "name": "deploy-base-rhel",
         "status": "successful",
-        "url": "/api/v2/workflow_jobs/1329/"
+        "url": "/api/v2/workflow_jobs/1329/",
+        "extra_vars": "{\"provider\": \"rhv\", \"host_type\": \"\"}"
     },
     {
         "id": 1337,
@@ -31,21 +32,19 @@
         },
         "name": "deploy-set-stats-for-jenkins",
         "artifacts": {
-            "JENKINS_EXPORT": {
-                "reported_devices": {
-                    "nics": [
-                        "lo",
-                        "eth0"
-                    ]
-                },
-                "host_type": "host",
-                "os_distribution_version": "7.8",
-                "fqdn": "fake.host.test.com",
-                "template": "",
-                "provider": "RHEV",
-                "os_distribution": "RedHat",
-                "name": "fake-physical-host"
-            }
+            "provider": "rhv",
+            "reported_devices": {
+                "nics": [
+                    "lo",
+                    "eth0"
+                ]
+            },
+            "host_type": "host",
+            "os_distribution_version": "7.8",
+            "fqdn": "fake.host.test.com",
+            "template": "",
+            "os_distribution": "RedHat",
+            "name": "fake-physical-host"
         }
     }
 ]

--- a/tests/providers/test_ansible_tower.py
+++ b/tests/providers/test_ansible_tower.py
@@ -97,6 +97,7 @@ def test_host_creation(tower_stub):
     host = tower_stub.construct_host(job, vmb.host_classes)
     assert isinstance(host, vmb.host_classes["host"])
     assert host.hostname == "fake.host.test.com"
+    assert host._broker_args == {"provider": "rhv", "host_type": "host"}
 
 
 def test_workflow_lookup_failure(tower_stub):


### PR DESCRIPTION
…Tower

This change allows broker to read the extra_vars in a workflow and
attempt to populate values in them from results returned back from
tower.
This will provide a more consistent behavior when duplicating a host.
Additionally, the new information can let users know exactly what they
got back from workflows that allow minimal or no arguments.