### PR TITLE
List AnsibleTower Inventories

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -14,6 +14,7 @@ PROVIDER_ACTIONS = {
     "job_template": (AnsibleTower, "execute"),
     "template": (AnsibleTower, None),  # needed for list-templates
     "test_action": (TestProvider, "test_action"),
+    "inventory": (AnsibleTower, None)
 }
 
 

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -57,8 +57,9 @@ def populate_providers(click_group):
             if prov_info[0] == prov_class
         ):
             action = action.replace("_", "-")
+            plural = action.replace('y', 'ies') if action.endswith('y') else f"{action}s"
             provider_cmd = click.option(
-                f"--{action}s", is_flag=True, help=f"Get available {action}s"
+                f"--{plural}", is_flag=True, help=f"Get available {plural}"
             )(provider_cmd)
             provider_cmd = click.option(
                 f"--{action}", type=str, help=f"Get information about a {action}"

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -304,6 +304,23 @@ class AnsibleTower(Provider):
                 workflows = results_filter(workflows, res_filter)
             workflows = "\n".join(workflows[:results_limit])
             logger.info(f"Available workflows:\n{workflows}")
+        elif kwargs.get("inventory"):
+            inv = [
+                {"Name": inv.name, "ID":inv.id, "Description":inv.description}
+                for inv in self.v2.inventory.get(kind="", page_size=1000).results
+            ]
+            logger.info(
+                f"Accepted additional nick fields:\n{helpers.yaml_format(inv)}"
+            )
+        elif kwargs.get("inventories"):
+            inv = [
+                inv.name
+                for inv in self.v2.inventory.get(kind="", page_size=1000).results
+            ]
+            if (res_filter := kwargs.get("results_filter")) :
+                inv = results_filter(inv, res_filter)
+            inv = "\n".join(inv[:results_limit])
+            logger.info(f"Available Inventories:\n{inv}")
         elif (job_template := kwargs.get("job_template")) :
             jt = self.v2.job_templates.get(name=job_template).results.pop()
             logger.info(

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -305,10 +305,8 @@ class AnsibleTower(Provider):
             workflows = "\n".join(workflows[:results_limit])
             logger.info(f"Available workflows:\n{workflows}")
         elif (inventory := kwargs.get("inventory")):
-            inv = [
-                {"Name": inv.name, "ID": inv.id, "Description": inv.description}
-                for inv in self.v2.inventory.get(name=inventory, kind="").results
-            ]
+            inv = self.v2.inventory.get(name=inventory, kind="").results.pop()
+            inv = {"Name": inv.name, "ID": inv.id, "Description": inv.description}
             logger.info(
                 f"Accepted additional nick fields:\n{helpers.yaml_format(inv)}"
             )

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -304,10 +304,10 @@ class AnsibleTower(Provider):
                 workflows = results_filter(workflows, res_filter)
             workflows = "\n".join(workflows[:results_limit])
             logger.info(f"Available workflows:\n{workflows}")
-        elif kwargs.get("inventory"):
+        elif (inventory := kwargs.get("inventory")):
             inv = [
-                {"Name": inv.name, "ID":inv.id, "Description":inv.description}
-                for inv in self.v2.inventory.get(kind="", page_size=1000).results
+                {"Name": inv.name, "ID": inv.id, "Description": inv.description}
+                for inv in self.v2.inventory.get(name=inventory, kind="").results
             ]
             logger.info(
                 f"Accepted additional nick fields:\n{helpers.yaml_format(inv)}"


### PR DESCRIPTION
**Description:**

With the incoming requirement to have broker accept and pass along inventory information, it would be nice to let users be able to figure out what queries are available.

Desired usage:
Get a list of inventories your account has access to.

**broker providers AnsibleTower --inventories**

Optional usage:
Get some relevant information about an inventory.

**broker providers AnsibleTower --inventory test-inventory**

Test Results:

![Screenshot from 2021-02-05 15-04-09](https://user-images.githubusercontent.com/26364615/107083310-6d999f00-67c3-11eb-95f3-e6f968f4c374.png)
