### PR TITLE
Log the workflow/job-template link on failure

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -253,12 +253,16 @@ class AnsibleTower(Provider):
         job_number = job.url.rstrip("/").split("/")[-1]
         job_ui_url = url_parser.urljoin(AT_URL, f"/#/{subject}s/{job_number}")
         logger.info(
-            f"Waiting for job: \nAPI: {url_parser.urljoin(AT_URL, str(job.url))}\nUI: {job_ui_url}"
+            "Waiting for job: \n"
+            f"API: {url_parser.urljoin(AT_URL, str(job.url))}\n"
+            f"UI: {job_ui_url}"
         )
         job.wait_until_completed(timeout=AT_TIMEOUT)
         if not job.status == "successful":
             logger.error(
-                f"{subject.capitalize()} Status: {job.status}\nExplanation: {job.job_explanation}"
+                f"{subject.capitalize()} Status: {job.status}\n"
+                f"Explanation: {job.job_explanation}\n"
+                f"UI: {job_ui_url}"
             )
             return
         if (artifacts := kwargs.get("artifacts")):


### PR DESCRIPTION
Its unclear during checkouts with `--count >1` which of the workflows has failed.


```
broker --log-level debug checkout --workflow deploy-workflow --count 3
 [...]
  [I 210205 21:14:54 ansible_tower:255] Waiting for job: 
     API: https://<host>/api/v2/workflow_jobs/236262/
     UI: https://<host>/#/workflows/236262
 [I 210205 21:14:54 ansible_tower:255] Waiting for job: 
     API: https://<host>/api/v2/workflow_jobs/236263/
     UI: https://<host>/#/workflows/236263
 [I 210205 21:14:54 ansible_tower:255] Waiting for job: 
     API: https://<host>/api/v2/workflow_jobs/236264/
     UI: https://<host>/#/workflows/236264
 [E 210205 21:18:06 ansible_tower:260] Workflow Status: failed
     Explanation: No error handling paths found, marking workflow as failed
 [D 210205 21:18:06 broker:91] None
 [D 210205 21:18:06 broker:112] host=None connect=False
 [E 210205 21:18:07 ansible_tower:260] Workflow Status: failed
     Explanation: No error handling paths found, marking workflow as failed
```