### PR TITLE
Handle empty nicks list

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -128,7 +128,7 @@ def resolve_nick(nick):
 
     :return: a dictionary mapping argument names and values
     """
-    nick_names = settings.settings.get("NICKS", {})
+    nick_names = settings.settings.get("NICKS") or {}
     if nick in nick_names:
         return settings.settings.NICKS[nick].to_dict()
 


### PR DESCRIPTION
If the nicks list in `broker_settings.yaml` is empty, `nick_names` gets set to `None` resulting in a `TypeError`.