### PR TITLE
Made a singular provider instance the default automatically

### DIFF
--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -30,7 +30,7 @@ class Provider:
             if instance_name in candidate:
                 instance = candidate
                 default = False
-            elif candidate.values()[0].get("default"):
+            elif candidate.values()[0].get("default") or len(fresh_settings.instances) == 1:
                 instance = candidate
                 default = True
         fresh_settings.update(instance.values()[0])


### PR DESCRIPTION
This makes it so you don't have to put extraneous config keys when there is only one provider instance available.

Without `default: true` in your settings, you'll see a pretty obtuse exception that doesn't really indicate what's wrong:

```
  File "/home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/broker/broker.py", line 222, in sync_inventory
    prov_inventory = PROVIDERS[provider](**instance).get_inventory(additional_arg)
  File "/home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/broker/providers/ansible_tower.py", line 45, in __init__
    self._validate_settings(instance_name)
  File "/home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/broker/providers/__init__.py", line 36, in _validate_settings
    fresh_settings.update(instance.values()[0])
AttributeError: 'NoneType' object has no attribute 'values'

```