### PR TITLE
Added the ability to pass in complex data structures via files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+0.1.10 (2021-02-26)
+------------------
+
++ Added the ability to pass in complex data structures via files
+
 0.1.9 (2021-01-29)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ To specify an instance a checkout should be performed against, pass a flag name 
 ```
 broker checkout --nick rhel7 --AnsibleTower testing
 ```
+If you have more complex data structures you need to pass in, you can do that in two ways.
+You can populate a json or yaml file where the top-level keys will become broker arguments and their nested data structures become values.
+```
+broker checkout --nick rhel7 --args-file tests/data/broker_args.json
+```
+You can also pass in a file for other arguments, where the contents will become the argument's value
+```
+broker checkout --nick rhel7 --extra tests/data/args_file.yaml
+```
 
 **Nicks**
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
 
 setup(
     name="broker",
-    version="0.1.9",
+    version="0.1.10",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/data/args_file.json
+++ b/tests/data/args_file.json
@@ -1,0 +1,10 @@
+[
+    {
+        "baseurl": "http://my.mirror/rpm",
+        "name": "base"
+    },
+    {
+        "baseurl": "http://my.mirror/rpm",
+        "name": "optional"
+    }
+]

--- a/tests/data/args_file.yaml
+++ b/tests/data/args_file.yaml
@@ -1,0 +1,4 @@
+- baseurl: http://my.mirror/rpm
+  name: base
+- baseurl: http://my.mirror/rpm
+  name: optional

--- a/tests/data/broker_args.json
+++ b/tests/data/broker_args.json
@@ -1,0 +1,13 @@
+{
+    "myarg": [
+        {
+            "baseurl": "http://my.mirror/rpm",
+            "name": "base"
+        },
+        {
+            "baseurl": "http://my.mirror/rpm",
+            "name": "optional"
+        }
+    ],
+    "my_second_arg": "foo"
+}

--- a/tests/data/broker_args.yaml
+++ b/tests/data/broker_args.yaml
@@ -1,0 +1,6 @@
+my_second_arg: foo
+myarg:
+- baseurl: http://my.mirror/rpm
+  name: base
+- baseurl: http://my.mirror/rpm
+  name: optional

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,37 @@
+from broker import helpers
+
+BROKER_ARGS_DATA = {
+    "myarg": [
+        {"baseurl": "http://my.mirror/rpm", "name": "base"},
+        {"baseurl": "http://my.mirror/rpm", "name": "optional"},
+    ],
+    "my_second_arg": "foo",
+}
+
+
+def test_load_json_file():
+    data = helpers.load_file("tests/data/broker_args.json")
+    assert data == BROKER_ARGS_DATA
+
+
+def test_load_yaml_file():
+    data = helpers.load_file("tests/data/broker_args.yaml")
+    assert data == BROKER_ARGS_DATA
+
+
+def test_negative_load_file():
+    data = helpers.load_file("this/doesnt/exist.something")
+    assert not data
+
+
+def test_resolve_file_args():
+    broker_args = {
+        "test_arg": "test_val",
+        "args_file": "tests/data/broker_args.json",
+        "complex_args": "tests/data/args_file.yaml"
+    }
+    new_args = helpers.resolve_file_args(broker_args)
+    assert "args_file" not in new_args
+    assert new_args["my_second_arg"] == "foo"
+    assert new_args["complex_args"] == BROKER_ARGS_DATA["myarg"]
+    assert new_args["test_arg"] == "test_val"


### PR DESCRIPTION
This change allows users to use files to store arguments.
Broker will attempt to resolve these files at runtime and pass them
along to the provider.
Since the values override the runtime broker_args, the resolved values
are stored in the inventory file so modified/destroyed files won't
result in improper behavior during a duplicate action.

fixes #87