### PR TITLE
Add the ability for broker to process ansible tower inventories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install: pip install .[test]
 script:
     - cp broker_settings.yaml.example broker_settings.yaml
-    - pytest
+    - pytest -v tests/ --ignore tests/cli_scenarios
 deploy:
     provider: pypi
     user: jacobcallahan

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 History
 =======
 
+0.1.11 (2021-03-26)
+------------------
+
++ Broker now handles ansible tower inventories
++ New exception handling system
++ New dynamic cli options for providers
++ Minor refactor and improvements
+
 0.1.10 (2021-02-26)
 ------------------
 

--- a/broker/__init__.py
+++ b/broker/__init__.py
@@ -1,0 +1,1 @@
+from broker.broker import VMBroker

--- a/broker/exceptions.py
+++ b/broker/exceptions.py
@@ -1,0 +1,36 @@
+"""A collection of Broker-specific exceptions"""
+from logzero import logger
+
+
+class BrokerError(Exception):
+    error_code = 1
+
+    def __init__(self, message="An unhandled exception occured!"):
+        if logger.level == 10 and isinstance(message, Exception):
+            logger.exception(message)
+        self.message = message
+        logger.error(f"{self.__class__.__name__}: {self.message}")
+
+
+class AuthenticationError(BrokerError):
+    error_code = 5
+
+
+class PermissionError(BrokerError):
+    error_code = 6
+
+
+class ProviderError(BrokerError):
+    error_code = 7
+
+    def __init__(self, provider, message):
+        self.message = f"{provider} encountered the following error: {message}"
+        super().__init__(message=self.message)
+
+
+class ConfigurationError(BrokerError):
+    error_code = 8
+
+
+class NotImplementedError(BrokerError):
+    error_code = 9

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from dynaconf import Dynaconf, Validator
 from dynaconf.validator import ValidationError
 from logzero import logger
+from broker.exceptions import ConfigurationError
 
 settings_file = "broker_settings.yaml"
 BROKER_DIRECTORY = Path()
@@ -14,6 +15,7 @@ if "BROKER_DIRECTORY" in os.environ:
         BROKER_DIRECTORY = envar_location
 
 settings_path = BROKER_DIRECTORY.joinpath("broker_settings.yaml")
+inventory_path = BROKER_DIRECTORY.joinpath("inventory.yaml")
 
 validators = [
     Validator("HOST_USERNAME", default="root"),
@@ -28,5 +30,6 @@ settings = Dynaconf(
 try:
     settings.validators.validate()
 except ValidationError as err:
-    logger.error(f"Configuration error in {settings_path.absolute()}: {err}")
-    sys.exit()
+    raise ConfigurationError(
+        f"Configuration error in {settings_path.absolute()}: {err.args[0]}"
+    )

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -13,6 +13,7 @@ AnsibleTower:
             username: "<username>"
             password: "<plain text password>"
             # token: "<AT personal access token>"
+            inventory: "inventory name"
             default: True
         - testing:
             base_url: "https://<ansible tower host>/"
@@ -20,6 +21,7 @@ AnsibleTower:
             username: "<username>"
             password: "<plain text password>"
             # token: "<AT personal access token>"
+            inventory: "inventory name"
     release_workflow: "remove-vm"
     extend_workflow: "extend-vm"
     workflow_timeout: 3600

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
 
 setup(
     name="broker",
-    version="0.1.10",
+    version="0.1.11",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",

--- a/tests/cli_scenarios/test_satlab.py
+++ b/tests/cli_scenarios/test_satlab.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import pytest
+from click.testing import CliRunner
+from broker.commands import cli
+from broker.providers.ansible_tower import AnsibleTower
+from broker.settings import inventory_path
+
+SCENARIO_DIR = Path("tests/data/cli_scenarios/satlab")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_if_not_configured():
+    try:
+        AnsibleTower()
+    except:
+        pytest.skip("AnsibleTower is not configured correctly")
+
+
+@pytest.fixture(scope="module")
+def temp_inventory():
+    """Temporarily move the local inventory, then move it back when done"""
+    backup_path = inventory_path.rename(f"{inventory_path.absolute()}.bak")
+    yield
+    CliRunner().invoke(cli, ["checkin", "--all"])
+    inventory_path.unlink()
+    backup_path.rename(inventory_path)
+
+
+@pytest.mark.parametrize(
+    "args_file", [f for f in SCENARIO_DIR.iterdir() if f.name.startswith("checkout_")]
+)
+def test_checkout_scenarios(args_file, temp_inventory):
+    result = CliRunner().invoke(cli, ["checkout", "--args-file", args_file])
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "args_file", [f for f in SCENARIO_DIR.iterdir() if f.name.startswith("execute_")]
+)
+def test_execute_scenarios(args_file):
+    result = CliRunner().invoke(cli, ["execute", "--args-file", args_file])
+    assert result.exit_code == 0
+
+
+def test_inventory_sync():
+    result = CliRunner().invoke(cli, ["inventory", "--sync", "AnsibleTower"])
+    assert result.exit_code == 0
+
+
+def test_workflows_list():
+    result = CliRunner().invoke(cli, ["providers", "AnsibleTower", "--workflows"])
+    assert result.exit_code == 0
+
+
+def test_workflow_query():
+    result = CliRunner().invoke(
+        cli, ["providers", "AnsibleTower", "--workflow", "list-templates"]
+    )
+    assert result.exit_code == 0

--- a/tests/data/cli_scenarios/satlab/checkout_latest_rhel.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_latest_rhel.yaml
@@ -1,0 +1,1 @@
+workflow: deploy-base-rhel

--- a/tests/data/cli_scenarios/satlab/checkout_latest_sat.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_latest_sat.yaml
@@ -1,0 +1,1 @@
+workflow: deploy-sat-jenkins

--- a/tests/data/cli_scenarios/satlab/checkout_rhel78.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_rhel78.yaml
@@ -1,0 +1,2 @@
+workflow: deploy-base-rhel
+rhel_version: "7.9"

--- a/tests/data/cli_scenarios/satlab/checkout_sat_69.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_sat_69.yaml
@@ -1,0 +1,2 @@
+workflow: deploy-sat-jenkins
+deploy_sat_version: "6.9"

--- a/tests/data/cli_scenarios/satlab/execute_templates_list.yaml
+++ b/tests/data/cli_scenarios/satlab/execute_templates_list.yaml
@@ -1,0 +1,3 @@
+workflow: list-templates
+artifacts: last
+output-format: raw

--- a/tests/data/cli_scenarios/satlab/execute_test_workflow.yaml
+++ b/tests/data/cli_scenarios/satlab/execute_test_workflow.yaml
@@ -1,0 +1,3 @@
+workflow: test-workflow
+artifacts: last
+output-format: yaml

--- a/tests/providers/test_ansible_tower.py
+++ b/tests/providers/test_ansible_tower.py
@@ -97,9 +97,10 @@ def test_host_creation(tower_stub):
     host = tower_stub.construct_host(job, vmb.host_classes)
     assert isinstance(host, vmb.host_classes["host"])
     assert host.hostname == "fake.host.test.com"
-    assert host._broker_args == {"provider": "rhv", "host_type": "host"}
+    assert host._broker_args["os_distribution_version"] == "7.8"
 
 
 def test_workflow_lookup_failure(tower_stub):
-    job = tower_stub.execute(workflow="this-does-not-exist")
-    assert job is None
+    with pytest.raises(VMBroker.ProviderError) as err:
+        tower_stub.execute(workflow="this-does-not-exist")
+    assert "Workflow not found by name: this-does-not-exist" in err.value.message

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from dynaconf import ValidationError
+from broker.exceptions import ConfigurationError
 from broker.providers.test_provider import TestProvider
 
 
@@ -17,9 +18,9 @@ def test_alternate_settings():
 
 
 def test_validator_trigger():
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ConfigurationError) as err:
         TestProvider(TestProvider="bad")
-    assert error.value.args == ("TestProvider.foo is required in env main",)
+    assert isinstance(err.value.args[0], ValidationError)
 
 
 def test_nested_envar():


### PR DESCRIPTION
Broker can now accept ansible tower inventories both via cli and config.
We now have a new exception handling system as well as a way to
gracefully handle kyboardinterrupts.
Providers can now specify checkout and execute cli arguments in their
class definition.
Minor refactor and improvements.