### PR TITLE
Allow users to not specify an inventory for AnsibleTower

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+0.1.13 (2021-04-14)
+------------------
+
++ AnsibleTower provider no longer requires a inventory specified.
+
 0.1.12 (2021-04-13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
 
 setup(
     name="broker",
-    version="0.1.12",
+    version="0.1.13",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This will not send the inventory payload and let tower decide the
inventory.