### PR TITLE
Turn host.session into a property

### DIFF
--- a/broker/session.py
+++ b/broker/session.py
@@ -105,7 +105,6 @@ class Session:
                 for size, data in download:
                     upload.write(data)
 
-
     def scp_write(self, source, destination=None):
         """scp write a local file to a remote destination"""
         if not destination:


### PR DESCRIPTION
If connect wasn't called, session can be referenced when it was None. Callers should be able to create a host instance and use its `execute` method without being forced to connect first. Broker should be responsible for handling that session connection.

This will replace session whenever `connect` is called.

Since connect is handled automatically along with the session property, there is no longer a need to track connected state through pickling, so `__setstate__` has been removed.

Example, where `host` was created with `VMBroker.from_inventory()`:

```
In [7]: host.execute('hostname')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-0a254b67faf4> in <module>
----> 1 host.execute('hostname')

~/repos/robottelo/.robottelo/lib64/python3.8/site-packages/broker/hosts.py in execute(self, command, timeout)
     49         timeout = timeout or self.default_timeout
     50         logger.debug(f"{self.hostname} executing command: {command}")
---> 51         res = self.session.run(command, timeout=timeout)
     52         logger.debug(f"{self.hostname} command result:\n{res}")
     53         return res

AttributeError: 'NoneType' object has no attribute 'execute'
```

This isn't a reasonable failure mode for broker's host.  The reference to session should create it if it doesn't exist yet.

With this change, `host.execute` can be called without having to explicitly call `host.connect` first.

With my example system being powered off, this results in a TimeoutError, as I would expect, instead of an AttributeError.

```
In [5]: host.run('hostname')
---------------------------------------------------------------------------
TimeoutError                              Traceback (most recent call last)
<ipython-input-5-0a254b67faf4> in <module>
----> 1 host.run('hostname')

~/repos/broker/broker/hosts.py in execute(self, command, timeout)
     70         timeout = timeout or self.default_timeout
     71         logger.debug(f"{self.hostname} executing command: {command}")
---> 72         res = self.session.run(command, timeout=timeout)
     73         logger.debug(f"{self.hostname} command result:\n{res}")
     74         return res

~/repos/broker/broker/hosts.py in session(self)
     24     def session(self):
     25         if not self._session:
---> 26             self.connect()
     27         return self._session
     28 

~/repos/broker/broker/hosts.py in connect(self, username, password)
     45         if self._session is not None:
     46             self.close()
---> 47         self._session = session.Session(
     48             hostname=self.hostname, username=username, password=password
     49         )

~/repos/broker/broker/session.py in __init__(self, **kwargs)
     36         user = kwargs.get("username", "root")
     37         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
---> 38         sock.connect((host, kwargs.get("port", 22)))
     39         self.session = ssh2_Session()
     40         self.session.handshake(sock)

TimeoutError: [Errno 110] Connection timed out

```