### PR TITLE
Make custom exceptions work with multiprocessing

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -119,7 +119,10 @@ class VMBroker:
         for action in self._provider_actions.keys():
             provider, method = PROVIDER_ACTIONS[action]
             logger.info(f"Using provider {provider.__name__} to checkout")
-            host = self._act(provider, method, checkout=True)
+            try:
+                host = self._act(provider, method, checkout=True)
+            except exceptions.ProviderError:
+                host = None
             logger.debug(f"host={host}")
             if host:
                 hosts.append(host)

--- a/broker/exceptions.py
+++ b/broker/exceptions.py
@@ -23,7 +23,7 @@ class PermissionError(BrokerError):
 class ProviderError(BrokerError):
     error_code = 7
 
-    def __init__(self, provider, message):
+    def __init__(self, provider=None, message="Unspecified exception"):
         self.message = f"{provider} encountered the following error: {message}"
         super().__init__(message=self.message)
 
@@ -39,6 +39,7 @@ class NotImplementedError(BrokerError):
 class HostError(BrokerError):
     error_code = 10
 
-    def __init__(self, host, message):
-        self.message = f"{host.hostname or host.name}: {message}"
+    def __init__(self, host=None, message="Unspecified exception"):
+        if host:
+            self.message = f"{host.hostname or host.name}: {message}"
         super().__init__(message=self.message)


### PR DESCRIPTION
Set default values instead of required, this allows the exceptions
to be pickled by multiprocessing.
Also handled a case where no host would be returned.
fixes #104