### PR TITLE
Restrict AT workflow and job tempate output lists

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 History
 =======
 
+0.1.19 (2021-06-18)
+------------------
+
++ Host session objects are now a property
++ AnsibleTower will only display workflow and job templates
+  a user had permission to start
+
 0.1.18 (2021-05-27)
 ------------------
 

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -482,6 +482,7 @@ class AnsibleTower(Provider):
             workflows = [
                 workflow.name
                 for workflow in self.v2.workflow_job_templates.get().results
+                if workflow.summary_fields.user_capabilities.get("start")
             ]
             if (res_filter := kwargs.get("results_filter")) :
                 workflows = results_filter(workflows, res_filter)
@@ -509,6 +510,7 @@ class AnsibleTower(Provider):
             job_templates = [
                 job_template.name
                 for job_template in self.v2.job_templates.get().results
+                if job_template.summary_fields.user_capabilities.get("start")
             ]
             if (res_filter := kwargs.get("results_filter")) :
                 job_templates = results_filter(job_templates, res_filter)

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -1,9 +1,7 @@
 import os
-import sys
 from pathlib import Path
 from dynaconf import Dynaconf, Validator
 from dynaconf.validator import ValidationError
-from logzero import logger
 from broker.exceptions import ConfigurationError
 
 settings_file = "broker_settings.yaml"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
 
 setup(
     name="broker",
-    version="0.1.18",
+    version="0.1.19",
     description="The infrastructure middleman.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
AnsibleTower will only display workflow and job templates a user had permission to start

fixes #110