### PR TITLE
Add parallel checkin behavior as default

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -181,10 +181,11 @@ populate_providers(providers)
 @click.argument("vm", type=str, nargs=-1)
 @click.option("-b", "--background", is_flag=True, help="Run checkin in the background")
 @click.option("--all", "all_", is_flag=True, help="Select all VMs")
+@click.option("--sequential", is_flag=True, default=False, help="Run checkins sequentially")
 @click.option(
     "--filter", type=str, help="Checkin only what matches the specified filter"
 )
-def checkin(vm, background, all_, filter):
+def checkin(vm, background, all_, sequential, filter):
     """Checkin or "remove" a VM or series of VM broker instances
 
     COMMAND: broker checkin <vm hostname>|<local id>|all
@@ -192,6 +193,10 @@ def checkin(vm, background, all_, filter):
     :param vm: Hostname or local id of host
 
     :param background: run a new broker subprocess to carry out command
+
+    :param all_: Flag for whether to checkin everything
+
+    :param sequential: Flag for whether to run checkins sequentially
 
     :param filter: a filter string matching broker's specification
     """
@@ -203,7 +208,7 @@ def checkin(vm, background, all_, filter):
         if str(num) in vm or host["hostname"] in vm or host["name"] in vm or all_:
             to_remove.append(VMBroker().reconstruct_host(host))
     broker_inst = VMBroker(hosts=to_remove)
-    broker_inst.checkin()
+    broker_inst.checkin(sequential=sequential)
 
 
 @cli.command()


### PR DESCRIPTION
Sequential argument added for those that want it, but the default will be concurrent checkins.

Can't use mp_decorator due to its pattern of duplicating the same function kwargs, just using ProcessPoolExecutor directly

It's fairly subtle in the examples below because checkins ran without delay, but its clear in the sequential one it waited to start the task until the first checkin was complete.

Default concurrent checkin of multiple instances:
```
setup@localhost:~/repos/robottelo (master$%>) % broker checkin 0 1             
[INFO 210624 08:03:37] Using token authentication
[INFO 210624 08:03:38] Using token authentication
[INFO 210624 08:03:39] Checking in <host0>
[INFO 210624 08:03:39] Checking in <host1>
[INFO 210624 08:03:39] Using token authentication
[INFO 210624 08:03:39] Using token authentication
[INFO 210624 08:03:40] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698485/
    UI: https://<tower-provider>/#/workflows/698485
[INFO 210624 08:03:41] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698487/
    UI: https://<tower-provider>/#/workflows/698487
```

Sequential checkin of multiple instances:
```
setup@localhost:~/repos/robottelo (master$%>) % broker checkin --sequential 0 1
[INFO 210624 07:59:50] Using token authentication
[INFO 210624 07:59:51] Using token authentication
[INFO 210624 07:59:51] Checking in <host0>
[INFO 210624 07:59:51] Using token authentication
[INFO 210624 07:59:53] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698452/
    UI: https:/<tower-provider>/#/workflows/698452
[INFO 210624 08:01:26] Checking in <host1>
[INFO 210624 08:01:26] Using token authentication
[INFO 210624 08:01:28] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698472/
    UI: https://<tower-provider>/#/workflows/698472
```

Default concurrent checkin of single instance:
```
setup@localhost:~/repos/robottelo (master$%>) % broker checkin 0  
[INFO 210624 08:06:43] Using token authentication
[INFO 210624 08:06:44] Checking in <host0>
[INFO 210624 08:06:44] Using token authentication
[INFO 210624 08:06:46] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698511/
    UI: https:/<tower-provider>/#/workflows/698511

```

Checkin with a dictionary passed:
```
In [7]: host_dict = {'first':[hosts[0]], 'second': [hosts[1]]}

In [8]: broker.checkin(host=host_dict)

In [9]: 

## Logs
[INFO 210624 09:27:03] Checking in <host0>
[INFO 210624 09:27:03] Checking in <host1>
[INFO 210624 09:27:04] Using token authentication
[INFO 210624 09:27:04] Using token authentication
[INFO 210624 09:27:05] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698995/
    UI: https://<tower-provider>/#/workflows/698995
[INFO 210624 09:27:05] Waiting for job: 
    API: https://<tower-provider>/api/v2/workflow_jobs/698996/
    UI: https://<tower-provider>/#/workflows/698996

```