### PR TITLE
Move inventory update to after mp checkins complete

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -180,7 +180,6 @@ class VMBroker:
             pass
         if host in self._hosts:
             self._hosts.remove(host)
-        helpers.update_inventory(remove=host.hostname)
         return host
 
     def checkin(self, sequential=False, host=None):
@@ -213,6 +212,7 @@ class VMBroker:
             for completed in completed_checkins:
                 _host = completed.result()
                 logger.debug(f'Completed checkin process for {_host.hostname or _host.name}')
+        helpers.update_inventory(remove=[h.hostname for h in hosts])
 
     def extend(self, host=None):
         """extend one or more VMs


### PR DESCRIPTION
Move the inventory update out of the MP process for checkin, attempt to mitigate pickle encoding characters breaking yaml parsing.

Observed during single host checkin with ContentHost hosts from robottelo. 

@JacobCallahan is also looking at a pattern to make host instances pickle-safe.  Throwing this up for visibility.

```
Traceback (most recent call last):
  File "/usr/lib64/python3.8/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/broker/broker.py", line 183, in _checkin
    helpers.update_inventory(remove=host.hostname)
  File "/opt/app-root/lib64/python3.8/site-packages/broker/helpers.py", line 224, in update_inventory
    inv_data = load_inventory()
  File "/opt/app-root/lib64/python3.8/site-packages/broker/helpers.py", line 204, in load_inventory
    inv_data = load_file(inventory_file)
  File "/opt/app-root/lib64/python3.8/site-packages/broker/helpers.py", line 165, in load_file
    data = loader.load(f, **loader_args) or []
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/__init__.py", line 112, in load
    loader = Loader(stream)
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/loader.py", line 24, in __init__
    Reader.__init__(self, stream)
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/reader.py", line 135, in determine_encoding
    self.update(1)
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/reader.py", line 169, in update
    self.check_printable(data)
  File "/opt/app-root/lib64/python3.8/site-packages/yaml/reader.py", line 143, in check_printable
    raise ReaderError(self.name, position, ord(character),
yaml.reader.ReaderError: unacceptable character #x0000: special characters are not allowed
  in "/opt/app-root/src/robottelo/inventory.yaml", position 3
"""

The above exception was the direct cause of the following exception:
pytest_fixtures/broker.py:62: in rhel7_contenthost
    yield host
../../lib64/python3.8/site-packages/broker/broker.py:309: in __exit__
    self.checkin()
../../lib64/python3.8/site-packages/broker/broker.py:214: in checkin
    _host = completed.result()
/usr/lib64/python3.8/concurrent/futures/_base.py:432: in result
    return self.__get_result()
/usr/lib64/python3.8/concurrent/futures/_base.py:388: in __get_result
    raise self._exception
E   yaml.reader.ReaderError: unacceptable character #x0000: special characters are not allowed
E     in "/opt/app-root/src/robottelo/inventory.yaml", position 3

```