### PR TITLE
Remove context from update broker image workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy to PyPi
+name: PythonPackage
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    name: Build and Deploy to PyPi
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,8 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        path: "broker"
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/update_broker_image.yml
+++ b/.github/workflows/update_broker_image.yml
@@ -1,4 +1,4 @@
-name: update_broker_image
+name: ContainerImage
 
 on:
   push:
@@ -12,19 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          path: "broker"
-
-#      - name: Get image tag
-#        id: image_tag
-#        run: |
-#          echo -n ::set-output name=IMAGE_TAG::
-#          TAG="${GITHUB_REF##*/}"
-#          if [ "${TAG}" == "master" ]; then
-#              TAG="latest"
-#          fi
-#          echo "${TAG}"
-# to reference this tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -42,7 +29,6 @@ jobs:
       - name: Build and push image to Quay
         uses: docker/build-push-action@v2
         with:
-          context: .
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.QUAY_SERVER }}/${{ secrets.QUAY_NAMESPACE }}/broker:latest

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ History
 
 + Improved concurrent checkin resilience
 + Increased AnsibleTower page size for workflows and job templates
++ GHA Updates
 
 0.1.20 (2021-06-25)
 ------------------


### PR DESCRIPTION
Added to try and make it compatible with nektos/act, but breaks
container build in GHA as-is.

Updating history because it has to be updated for workflows to trigger