### PR TITLE
Check for empty hosts in VMBroker.checkin

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+0.1.22 (2021-07-16)
+------------------
+
++ Handle checkin on instance with no hosts
++ Handle Pickle raising an AttributeError
+
 0.1.21 (2021-07-01)
 ------------------
 

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -205,6 +205,11 @@ class VMBroker:
             hosts = [host for host_list in hosts.values() for host in host_list]
         if not isinstance(hosts, list):
             hosts = [hosts]
+
+        if not hosts:
+            logger.debug('Checkin called with no hosts, taking no action')
+            return
+
         with ProcessPoolExecutor(
             max_workers=1 if sequential else len(hosts)
         ) as workers:

--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -44,7 +44,7 @@ class Host:
         for key, obj in self.__dict__.items():
             try:
                 pickle.dumps(obj)
-            except pickle.PicklingError:
+            except (pickle.PicklingError, AttributeError):
                 self.__dict__[key] = None
 
     def connect(self, username=None, password=None):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -44,6 +44,13 @@ def test_broker_e2e():
     assert len(broker_inst._hosts) == 0
 
 
+def test_broker_empty_checkin():
+    """Try to checkin with no hosts on the instance"""
+    broker_inst = broker.VMBroker(nick="test_nick")
+    assert not broker_inst._hosts
+    broker_inst.checkin()
+
+
 def test_mp_checkout():
     """Test that broker can checkout multiple hosts using multiprocessing"""
     VM_COUNT=50  # This is intentionaly made high to catch run condition that


### PR DESCRIPTION
I found that checkin was getting called against an instance that had no
hosts, triggering a ValueError because 0 was getting passed for
max_workers to ProcessPoolExecutor

Changed the context manager to not capture and try to checkin when no
hosts were created.

Checked that hosts isn't empty in VMBroker.checkin

Added unit test that reproduced the error