### PR TITLE
Move to setup.cfg, use setuptools-scm for versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,7 +3,7 @@ name: PythonPackage
 on:
   push:
     branches: [master]
-    paths: ['HISTORY.md']
+    tags: ["*"]
 
 jobs:
   publish:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,43 @@
-[bdist_wheel]
-universal = 1
+[metadata]
+name = broker
+description = The infrastructure middleman.
+long_description = file: README.md, HISTORY.md
+long_description_content_type = text/markdown
+author = Jacob J Callahan
+author_email = jacob.callahan05@gmail.com
+url = https://github.com/SatelliteQE/broker
+license = GNU General Public License v3
+keywords = broker, AnsibleTower
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Natural Language :: English
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+install_requires =
+    awxkit
+    click
+    dynaconf>=3.1.0
+    logzero
+    pyyaml
+    setuptools
+    ssh2-python
+packages = find:
+zip_safe = False
+
+[options.extras_require]
+test = pytest
+setup = 
+    setuptools
+    setuptools-scm
+    wheel
+    twine
+
+[options.entry_points]
+console_scripts = 
+    broker = broker.commands:cli
+

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,7 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+from setuptools import setup
 
-with open("README.md") as readme_file:
-    readme = readme_file.read()
-
-with open("HISTORY.md") as history_file:
-    history = history_file.read()
-
-requirements = [
-    "awxkit", "click", "dynaconf>=3.1.0", "logzero", "pyyaml", "setuptools", "ssh2-python"]
-
-test_requirements = ['pytest']
-setup_requirements = ['setuptools', 'wheel', 'twine']
-
-extras = {
-    'test': test_requirements,
-    'setup': setup_requirements,
-}
 
 setup(
-    name="broker",
-    version="0.1.21",
-    description="The infrastructure middleman.",
-    long_description=readme + "\n\n" + history,
-    long_description_content_type="text/markdown",
-    author="Jacob J Callahan",
-    author_email="jacob.callahan05@gmail.com",
-    url="https://github.com/SatelliteQE/broker",
-    packages=find_packages(),
-    entry_points={"console_scripts": ["broker=broker.commands:cli"]},
-    install_requires=requirements,
-    tests_require=test_requirements,
-    extras_require=extras,
-    setup_requires=setup_requirements,
-    license="GNU General Public License v3",
-    zip_safe=False,
-    keywords="broker",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
+    use_scm_version=True,
 )


### PR DESCRIPTION
This commit implies we will begin to use git tags to control versioning in broker, instead of a static version number in setup.py.

We'll still manually update HISTORY.md with contextual information about tagged versions.