### PR TITLE
Better job error handling for AnsibleTower

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ History
 
 + Handle checkin on instance with no hosts
 + Handle Pickle raising an AttributeError
++ Better error handling for AnsibleTower
 
 0.1.21 (2021-07-01)
 ------------------

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -45,6 +45,8 @@ def populate_providers(click_group):
         --workflows      Get available workflows
         --workflow TEXT  Get information about a workflow
         --help           Show this message and exit.
+
+    Note: This currently only works for the default instance for each provider
     """
     for prov, prov_class in (pairs for pairs in PROVIDERS.items()):
 


### PR DESCRIPTION
This change allows broker to also handle jobs that error out instead
of simply failing. It also provides a generic error message if none
could be found.