### PR TITLE
Limit python-publish to tags only

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,8 +2,8 @@ name: PythonPackage
 
 on:
   push:
-    branches: [master]
-    tags: ["*"]
+    tags: 
+      - "*"
 
 jobs:
   publish:


### PR DESCRIPTION
Might _have_ to use an `if` statement in the job body, but I'd like to keep things simpler if possible.