### PR TITLE
Made CLI checkouts properly raise exceptions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-venv/
+venv*/
 build/
 develop-eggs/
 dist/

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+0.1.27 (2021-10-29)
+------------------
+
++ Made CLI checkouts properly raise exceptions
+
 0.1.26 (2021-10-05)
 ------------------
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+0.1.28 (2021-11-03)
+------------------
+
++ Suppress warnings on inventory load
++ Move file arg evaluation to VMBroker's init
+
 0.1.27 (2021-10-29)
 ------------------
 

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -163,7 +163,6 @@ def checkout(ctx, background, nick, count, args_file, **kwargs):
             for key, val in zip(ctx.args[::2], ctx.args[1::2])
         }
     )
-    broker_args = helpers.resolve_file_args(broker_args)
     if background:
         helpers.fork_broker()
     broker_inst = VMBroker(**broker_args)
@@ -375,7 +374,6 @@ def execute(ctx, background, nick, output_format, artifacts, args_file, **kwargs
             for key, val in zip(ctx.args[::2], ctx.args[1::2])
         }
     )
-    broker_args = helpers.resolve_file_args(broker_args)
     if background:
         helpers.fork_broker()
     broker_inst = VMBroker(**broker_args)

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -150,11 +150,12 @@ def resolve_nick(nick):
         return settings.settings.NICKS[nick].to_dict()
 
 
-def load_file(file):
+def load_file(file, warn=True):
     """Verifies existence and loads data from json and yaml files"""
     file = Path(file)
     if not file.exists() or file.suffix not in (".json", ".yaml", ".yml"):
-        logger.warning(f"File {file.absolute()} is invalid or does not exist.")
+        if warn:
+            logger.warning(f"File {file.absolute()} is invalid or does not exist.")
         return []
     loader_args = {}
     if file.suffix == ".json":
@@ -202,7 +203,7 @@ def load_inventory(filter=None):
     inventory_file = settings.BROKER_DIRECTORY.joinpath(
         settings.settings.INVENTORY_FILE
     )
-    inv_data = load_file(inventory_file)
+    inv_data = load_file(inventory_file, warn=False)
     return inv_data if not filter else inventory_filter(inv_data, filter)
 
 


### PR DESCRIPTION
This will pass along an exception object from the mp checkouts and
then check/raise them later. In a CLI environment, this will also give
us the correct exit code