### PR TITLE
Added a locking mechanism to actions that modify files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+0.1.31 (2021-11-11)
+------------------
+
++ Added a locking mechanism to actions that modify files
+
 0.1.30 (2021-11-05)
 ------------------
 


### PR DESCRIPTION
This should help us mitigate the occasional race conditions when
multiple instances of broker are attempting to update a single local
inventory file.