### PR TITLE
fix intermittent false exit status reads from commands

### DIFF
--- a/broker/session.py
+++ b/broker/session.py
@@ -72,8 +72,10 @@ class Session:
         channel.execute(
             command,
         )
-        results = self._read(channel)
+        channel.wait_eof()
         channel.close()
+        channel.wait_closed()
+        results = self._read(channel)
         return results
 
     def shell(self, pty=False):


### PR DESCRIPTION
We're hitting an issue, where we obtain a false exit status from a `.run()` method (currently only on a rhel9 host, which is interesting - but the VM is created using different template, so the HW profile might be different [slower VM]):
```
(Pdb++) for i in range(100): foo = host2.session.run('rpm -qa |grep katello-ca-consumer'); print(f'{foo.status}, {foo.stdout}, {foo.stderr}')
0, , (0, b'')
1, , (0, b'')
1, , (0, b'')
1, , (0, b'')
1, , (0, b'')
0, , (0, b'')
1, , (0, b'')
...
```

After some investigation, i found [this example](https://github.com/ParallelSSH/ssh2-python/blob/master/examples/example_echo.py#L36-L44) in the upstream lib, that gives me the correct exit_status every time.

Comparing to what we have in our code base, it looks like we try to read the channel before actually closing it.
This PR rearranges the steps and adds some extra method calls to ensure the channel gets closed.

this change seems to fix the issue:

```
In [5]: for i in range(100): foo = host2.sessio
   ...: n.run('ls | grep nonsense', timeout="10
   ...: 0000"); print(f'{foo.status}, {foo.stde
   ...: rr}')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
1, (0, b'')
...
```

for regression testing, i only tried to run some other command and tried to access the stdout, stderr and exit statuses:


```
In [12]: host2.execute('ls /').stdout
Out[12]: 'afs\nbin\nboot\ndev\netc\nhome\nlib\nlib64\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar\n'

In [13]: host2.run('ls /')
Out[13]: 
afs
bin
boot
dev
etc
home
lib
lib64
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var

...
In [15]: host2.run('ls non-existing').stderr
Out[15]: (60, b"ls: cannot access 'non-existing': No such file or directory\n")

In [16]: host2.run('ls non-existing').status
Out[16]: 2
```

