### PR TITLE
Load env file for dynaconf

### DIFF
--- a/broker/settings.py
+++ b/broker/settings.py
@@ -25,6 +25,8 @@ settings = Dynaconf(
     settings_file=str(settings_path.absolute()),
     ENVVAR_PREFIX_FOR_DYNACONF="BROKER",
     validators=validators,
+    load_dotenv=True,
+    ignore_unknown_envvars=True,
 )
 
 try:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,6 +9,7 @@ def test_default_settings():
     test_provider = TestProvider()
     assert test_provider.instance_name == "default"
     assert test_provider.foo == "bar"
+    assert test_provider.config == "something"
 
 
 def test_alternate_settings():
@@ -23,34 +24,43 @@ def test_validator_trigger():
     assert isinstance(err.value.args[0], ValidationError)
 
 
-def test_nested_envar():
+def test_nested_envar(request):
     """Set a value nested under an instance via environment variable
     then verify that the value makes it to the correct level.
     """
     os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"] = "bar"
+    @request.addfinalizer
+    def _clean():
+        del os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"]
+
     test_provider = TestProvider(TestProvider="test2")
     assert test_provider.instance_name == "test2"
     assert test_provider.foo == "baz"
-    del os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"]
 
 
-def test_default_envar():
+def test_default_envar(request):
     """Set a top-level instance value via environment variable
     then verify that the value is not overriden when the provider is selected by default.
     """
-    os.environ["BROKER_TESTPROVIDER__foo"] = "envar"
+    os.environ["BROKER_TESTPROVIDER__config_value"] = "envar"
+    @request.addfinalizer
+    def _clean():
+        del os.environ["BROKER_TESTPROVIDER__config_value"]
+        
     test_provider = TestProvider()
     assert test_provider.instance_name == "default"
-    assert test_provider.foo == "envar"
-    del os.environ["BROKER_TESTPROVIDER__foo"]
+    assert test_provider.config == "envar"
 
 
-def test_nondefault_envar():
+def test_nondefault_envar(request):
     """Set a top-level instance value via environment variable
     then verify that the value has been overriden when the provider is specified.
     """
     os.environ["BROKER_TESTPROVIDER__foo"] = "override me"
+    @request.addfinalizer
+    def _clean():
+        del os.environ["BROKER_TESTPROVIDER__foo"]
+
     test_provider = TestProvider(TestProvider="test1")
     assert test_provider.instance_name == "test1"
     assert test_provider.foo == "bar"
-    del os.environ["BROKER_TESTPROVIDER__foo"]


### PR DESCRIPTION
There is an issue with dynaconf - still being discussed and written as
an RFE upstream - where consumers of broker are using `.env` files and
configuring their dynaconf instances to read this file.

This causes the broker dynaconf instance to have a partial config based
on the `.env` file from the broker consumer, resulting in a broken
broker dynaconf instance.

In the particular case, robottelo is using broker and is storing
dynaconf vault config within the .env file. The vault config is not
complete, and within broker the settings instance throws exceptions
trying to read from vault.

I would consider this change a workaround for the behavior, not a real
resolution.

It should not interfere with the direct use of broker, or the use of
broker by consumers that are not using vault and not using an env file.