### PR TITLE
Add workaround to disable dynaconf vault loading

### DIFF
--- a/broker/settings.py
+++ b/broker/settings.py
@@ -25,8 +25,6 @@ settings = Dynaconf(
     settings_file=str(settings_path.absolute()),
     ENVVAR_PREFIX_FOR_DYNACONF="BROKER",
     validators=validators,
-    load_dotenv=True,
-    ignore_unknown_envvars=True,
 )
 
 try:

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -21,11 +21,19 @@ validators = [
     Validator("HOST_CONNECTION_TIMEOUT", default=None),
     Validator("HOST_SSH_PORT", default=22),
 ]
+
+# temportary fix for dynaconf #751
+vault_vars = {k: v for k, v in os.environ.items() if "VAULT_" in k}
+for k in vault_vars:
+    del os.environ[k]
+
 settings = Dynaconf(
     settings_file=str(settings_path.absolute()),
     ENVVAR_PREFIX_FOR_DYNACONF="BROKER",
     validators=validators,
 )
+# to make doubly sure, remove the vault loader if set somehow
+settings._loaders = [loader for loader in settings._loaders if not "vault" in loader]
 
 try:
     settings.validators.validate()
@@ -33,3 +41,5 @@ except ValidationError as err:
     raise ConfigurationError(
         f"Configuration error in {settings_path.absolute()}: {err.args[0]}"
     )
+
+os.environ.update(vault_vars)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,7 +9,6 @@ def test_default_settings():
     test_provider = TestProvider()
     assert test_provider.instance_name == "default"
     assert test_provider.foo == "bar"
-    assert test_provider.config == "something"
 
 
 def test_alternate_settings():
@@ -24,43 +23,34 @@ def test_validator_trigger():
     assert isinstance(err.value.args[0], ValidationError)
 
 
-def test_nested_envar(request):
+def test_nested_envar():
     """Set a value nested under an instance via environment variable
     then verify that the value makes it to the correct level.
     """
     os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"] = "bar"
-    @request.addfinalizer
-    def _clean():
-        del os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"]
-
     test_provider = TestProvider(TestProvider="test2")
     assert test_provider.instance_name == "test2"
     assert test_provider.foo == "baz"
+    del os.environ["BROKER_TESTPROVIDER__INSTANCES__TEST2__foo"]
 
 
-def test_default_envar(request):
+def test_default_envar():
     """Set a top-level instance value via environment variable
     then verify that the value is not overriden when the provider is selected by default.
     """
-    os.environ["BROKER_TESTPROVIDER__config_value"] = "envar"
-    @request.addfinalizer
-    def _clean():
-        del os.environ["BROKER_TESTPROVIDER__config_value"]
-        
+    os.environ["BROKER_TESTPROVIDER__foo"] = "envar"
     test_provider = TestProvider()
     assert test_provider.instance_name == "default"
-    assert test_provider.config == "envar"
+    assert test_provider.foo == "envar"
+    del os.environ["BROKER_TESTPROVIDER__foo"]
 
 
-def test_nondefault_envar(request):
+def test_nondefault_envar():
     """Set a top-level instance value via environment variable
     then verify that the value has been overriden when the provider is specified.
     """
     os.environ["BROKER_TESTPROVIDER__foo"] = "override me"
-    @request.addfinalizer
-    def _clean():
-        del os.environ["BROKER_TESTPROVIDER__foo"]
-
     test_provider = TestProvider(TestProvider="test1")
     assert test_provider.instance_name == "test1"
     assert test_provider.foo == "bar"
+    del os.environ["BROKER_TESTPROVIDER__foo"]


### PR DESCRIPTION
This change is needed due to dynaconf #751. This happens when broker is
being used in a project that is using dynaconf's vault integration.

Also reverted the previous try for good measure