### PR TITLE
Add the ability to determine caller origin for AnsibleTower workflows

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -1,4 +1,6 @@
 """Miscellaneous helpers live here"""
+import getpass
+import inspect
 import json
 import logging
 import os
@@ -489,3 +491,17 @@ class Result:
             stdout=nonduplex_exec.output.decode("utf-8"),
             stderr="",
         )
+
+
+def find_origin():
+    """Move up the call stack to find tests, fixtures, or cli invocations"""
+    prev = None
+    for frame in inspect.stack():
+        if frame.function == "checkout" and frame.filename.endswith("broker/commands.py"):
+            return f"broker_cli:{getpass.getuser()}"
+        if frame.function.startswith("test_"):
+            return f"{frame.function}:{frame.filename}"
+        if frame.function == "call_fixture_func":
+            return prev or "Uknown fixture"
+        prev = f"{frame.function}:{frame.filename}"
+    return f"Unknown origin by {getpass.getuser()}"

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -6,7 +6,7 @@ from urllib import parse as url_parser
 from functools import cached_property
 from dynaconf import Validator
 from broker import exceptions
-from broker.helpers import results_filter
+from broker.helpers import find_origin, results_filter
 from broker.settings import settings
 from logzero import logger
 from datetime import datetime
@@ -416,6 +416,7 @@ class AnsibleTower(Provider):
         if name := kwargs.get("workflow"):
             subject = "workflow"
             get_path = self.v2.workflow_job_templates
+            kwargs["_broker_origin"] = find_origin()
         elif name := kwargs.get("job_template"):
             subject = "job_template"
             get_path = self.v2.job_templates


### PR DESCRIPTION
This is currently a mandatory feature, but will likely be optional or completely removed in the future.
Right now, there are 4 classifications of origin points:
1. Broker CLI
2. Test Function
3. Pytest Fixture
4. Unkown