### PR TITLE
Allow simpler passing for individual host classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ from broker.hosts import Host
 class MyHost(Host):
    ...
 
-with Broker(..., host_classes={'host': MyHost}) as my_host:
+with Broker(..., host_class=MyHost) as my_host:
     ...
 ```
 

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -105,7 +105,10 @@ class Broker:
             nick = kwargs.pop("nick")
             kwargs = helpers.merge_dicts(kwargs, helpers.resolve_nick(nick))
             logger.debug(f"kwargs after nick resolution {kwargs=}")
-        if "host_classes" in kwargs:
+        # Allow users to more simply pass a host class instead of a dict
+        if "host_class" in kwargs:
+            self.host_classes["host"] = kwargs.pop("host_class")
+        elif "host_classes" in kwargs:
             self.host_classes.update(kwargs.pop("host_classes"))
         # determine the provider actions based on kwarg parameters
         self._provider_actions = {}


### PR DESCRIPTION
Most used of Broker are for simple (single host type per operation) cases.
Becuase of this, most users passing in custom host classes are passing in a single class.
In these cases, it makes more sense to allow for an easier way to pass along the class than to specify it via key/Class mappings.