### PR TITLE
Simulate SSH Session functionality with Container-based Hosts

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -397,7 +397,7 @@ class AnsibleTower(Provider):
                 if key.endswith("host_type"):
                     host_type = value if value in host_classes else host_type
             if not hostname:
-                raise Exception(f"No hostname found in job attributes:\n{job_attrs}")
+                logger.warning(f"No hostname found in job attributes:\n{job_attrs}")
             logger.debug(f"hostname: {hostname}, name: {name}, host type: {host_type}")
             host_inst = host_classes[host_type](
                 **{**kwargs, "hostname": hostname, "name": name}

--- a/tests/data/cli_scenarios/containers/checkout_ch-d_ubi8.yaml
+++ b/tests/data/cli_scenarios/containers/checkout_ch-d_ubi8.yaml
@@ -1,1 +1,1 @@
-container_host: ch-d:ubi8
+container_host: ubi8:latest

--- a/tests/data/cli_scenarios/containers/execute_ch-d_ubi8.yaml
+++ b/tests/data/cli_scenarios/containers/execute_ch-d_ubi8.yaml
@@ -1,2 +1,2 @@
-container_app: ch-d:ubi8
+container_app: ubi8:latest
 command: "ls -lah"

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -59,7 +59,7 @@ def test_containerhosts_list():
 
 def test_containerhost_query():
     result = CliRunner().invoke(
-        cli, ["providers", "Container", "--container-host", "ch-d:ubi8"]
+        cli, ["providers", "Container", "--container-host", "ubi8:latest"]
     )
     assert result.exit_code == 0
 
@@ -67,7 +67,11 @@ def test_containerhost_query():
 # ----- Broker API Tests -----
 
 def test_container_e2e():
-    with Broker(container_host="ch-d:ubi8") as c_host:
+    with Broker(container_host="ubi8:latest") as c_host:
         assert c_host._cont_inst.top()['Processes']
         res = c_host.execute("hostname")
         assert res.stdout.strip() == c_host.hostname
+        # Test that a file can be uploaded to the container
+        c_host.session.sftp_write("broker_settings.yaml", "/root")
+        res = c_host.execute("ls")
+        assert "broker_settings.yaml" in res.stdout


### PR DESCRIPTION
This change adds the ability to use "sftp" actions against containers.
This is done by (un)packing files in tar archives, which can be added/copied from running containers.
There isn't a current implementation to emulate an interactive shell, but that is likel possible with attach_socket.

I also made some unrelated optimizations to existing code.