### PR TITLE
Change the mp checkin max workers to default

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -33,7 +33,6 @@ def _try_teardown(host_obj):
         return exceptions.HostError(host_obj, f"error during teardown:\n{err}")
 
 
-
 class mp_decorator:
     """This decorator wraps Broker methods to enable multiprocessing
 
@@ -240,9 +239,7 @@ class Broker:
             logger.debug("Checkin called with no hosts, taking no action")
             return
 
-        with ProcessPoolExecutor(
-            max_workers=1 if sequential else len(hosts)
-        ) as workers:
+        with ProcessPoolExecutor(max_workers=1 if sequential else None) as workers:
             completed_checkins = as_completed(
                 # reversing over a copy of the list to avoid skipping
                 workers.submit(self._checkin, _host)


### PR DESCRIPTION
This change is largely for users attempting to check in a lot of hosts at once. When too many are being checked in, we can get in a situation where the user's OS' open files limit it reached. At that point, an exception is raised and no more hosts will be checked in.

By the new default, the checkin process will use as many workers as there are CPUs on the machine.