### PR TITLE
Get more specific with the origin information when in a pytest context

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -509,8 +509,12 @@ def find_origin():
         if frame.function.startswith("test_"):
             return f"{frame.function}:{frame.filename}", jenkins_url
         if frame.function == "call_fixture_func":
+            # attempt to find the test name from the fixture's request object
+            if request := _frame.frame.f_locals.get("request"):
+                return f"{prev} for {request.node._nodeid}", jenkins_url
+            # otherwise, return the fixture name and filename
             return prev or "Uknown fixture", jenkins_url
-        prev = f"{frame.function}:{frame.filename}"
+        prev, _frame = f"{frame.function}:{frame.filename}", frame
     return f"Unknown origin by {getpass.getuser()}", jenkins_url
 
 

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -254,7 +254,10 @@ class Container(Provider):
         if not kwargs.get("name"):
             kwargs["name"] = self._gen_name()
         kwargs["ports"] = self._port_mapping(container_host, **kwargs)
+        # add some context information about the container's requester
         envars, origin = {}, helpers.find_origin()
+        if "for" in origin:
+            origin = origin.split()[-1]
         envars["BROKER_ORIGIN"] = origin[0]
         if origin[1]:
             envars["JENKINS_URL"] = origin[1]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,6 +18,16 @@ def tmp_file(tmp_path):
     return tmp_path / "test.json"
 
 
+@pytest.fixture
+def basic_origin():
+    return helpers.find_origin()
+
+
+@pytest.fixture
+def request_origin(request):
+    return helpers.find_origin()
+
+
 def test_load_json_file():
     data = helpers.load_file("tests/data/broker_args.json")
     assert data == BROKER_ARGS_DATA
@@ -73,11 +83,20 @@ def test_lock_timeout(tmp_file):
     assert str(exc.value).startswith("Timeout while attempting to open")
 
 
-def test_find_origin():
+def test_find_origin_simple():
     origin = helpers.find_origin()
     assert len(origin) == 2
     assert origin[0].startswith("test_find_origin")
     assert origin[1] == None
+
+
+def test_find_origin_fixture(basic_origin):
+    assert basic_origin[0].startswith("basic_origin")
+
+
+def test_find_origin_fixture(request_origin):
+    """Test that we can get the request object information from the fixture"""
+    assert "test_find_origin_fixture" in request_origin[0]
 
 
 @pytest.mark.parametrize("set_envars", [("BUILD_URL", "fake")], indirect=True)


### PR DESCRIPTION
This change attempts to get the request object when we're running in a pytest fixture We then return the test location information gathered from the request object