### PR TITLE
Solve an issue with MP container checkouts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout repository
@@ -36,6 +36,6 @@ jobs:
     - name: Unit Tests
       run: |
         pip install -U pip
-        pip install -U .[test]
+        pip install -U .[test,docker]
         cp broker_settings.yaml.example broker_settings.yaml
         pytest -v tests/ --ignore tests/functional

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import os
+import pickle
 import sys
 import tarfile
 import time
@@ -548,3 +549,46 @@ def temporary_tar(paths):
             tar.add(path, arcname=path.name)
     yield temp_tar.absolute()
     temp_tar.unlink()
+
+
+class PickleSafe:
+    """A class that helps with pickling and unpickling complex objects"""
+
+    def _pre_pickle(self):
+        """This method is called before pickling an object"""
+        pass
+
+    def _post_pickle(self, purified):
+        """This method is called after pickling an object
+
+        purified will be a list of names of attributes that were removed
+        """
+        pass
+
+    def _purify(self):
+        """Strip all unpickleable attributes from a Host before pickling"""
+        self.purified = getattr(self, "purified", [])
+        for name in list(self.__dict__):
+            self._purify_target = name
+            try:
+                pickle.dumps(self.__dict__[name])
+            except (pickle.PicklingError, AttributeError):
+                self.__dict__[name] = None
+                self.purified.append(name)
+
+    def __getstate__(self):
+        """If a session is active, remove it for pickle compatability"""
+        self._pre_pickle()
+        try:
+            self._purify()
+        except RecursionError:
+                logger.warning(f"Recursion limit reached on {self._purify_target}")
+                self.__dict__[self._purify_target] = None
+                self.__getstate__()
+        self.__dict__.pop("_purify_target", None)
+        return self.__dict__
+
+    def __setstate__(self, state):
+        """Sometimes pickle strips things that we need. This should be used to restore them"""
+        self.__dict__.update(state)
+        self._post_pickle(purified=getattr(self, "purified", []))

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -2,11 +2,12 @@ import pickle
 import dynaconf
 
 from broker import exceptions
+from broker.helpers import PickleSafe
 from broker.settings import settings
 from logzero import logger
 
 
-class Provider:
+class Provider(PickleSafe):
     # Populate with a list of Dynaconf Validators specific to your provider
     _validators = []
     # Set to true if you don't want your provider shown in the CLI
@@ -33,6 +34,7 @@ class Provider:
 
         :param instance_name: A string matching an instance name
         """
+        instance_name = instance_name or getattr(self, "instance", None)
         section_name = self.__class__.__name__.upper()
         # make sure each instance isn't loading values from another
         fresh_settings = settings.get_fresh(section_name)

--- a/tests/data/cli_scenarios/satlab/checkout_rhel78.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_rhel78.yaml
@@ -1,2 +1,2 @@
 workflow: deploy-base-rhel
-rhel_version: "7.8"
+deploy_rhel_version: "7.8"

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -75,3 +75,15 @@ def test_container_e2e():
         c_host.session.sftp_write("broker_settings.yaml", "/root")
         res = c_host.execute("ls")
         assert "broker_settings.yaml" in res.stdout
+
+
+def test_container_e2e_mp():
+    with Broker(container_host="ubi8:latest", _count=2) as c_hosts:
+        for c_host in c_hosts:
+            assert c_host._cont_inst.top()['Processes']
+            res = c_host.execute("hostname")
+            assert res.stdout.strip() == c_host.hostname
+            # Test that a file can be uploaded to the container
+            c_host.session.sftp_write("broker_settings.yaml", "/root")
+            res = c_host.execute("ls")
+            assert "broker_settings.yaml" in res.stdout


### PR DESCRIPTION
An issue was identified where the _cont_inst property was being stripped from the modified Host class during MP checkouts.
The solution I opted for was to recreate the missing container instance post-pickle. This removed the entire need for the _cont_inst property.