### PR TITLE
Better handle situations where the parent directory doesn't exist during sftp

### DIFF
--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -84,6 +84,6 @@ def test_container_e2e_mp():
             res = c_host.execute("hostname")
             assert res.stdout.strip() == c_host.hostname
             # Test that a file can be uploaded to the container
-            c_host.session.sftp_write("broker_settings.yaml", "/root")
-            res = c_host.execute("ls")
+            c_host.session.sftp_write("broker_settings.yaml", "/tmp/fake/")
+            res = c_host.execute("ls /tmp/fake")
             assert "broker_settings.yaml" in res.stdout

--- a/tests/functional/test_satlab.py
+++ b/tests/functional/test_satlab.py
@@ -68,3 +68,6 @@ def test_tower_host():
     with Broker(workflow="deploy-base-rhel") as r_host:
         res = r_host.execute("hostname")
         assert res.stdout.strip() == r_host.hostname
+        r_host.session.sftp_write("broker_settings.yaml", "/tmp/fake/")
+        res = r_host.execute("ls /tmp/fake")
+        assert "broker_settings.yaml" in res.stdout


### PR DESCRIPTION
This change adds some additional logic to not only handle when parent directories don't exist, but also constructs the destination path when only a directory is given

Fixes #169

Both affected functional tests pass