### PR TITLE
REBASED: Make Broker able to log more verbosely

### DIFF
--- a/broker/binds/containers.py
+++ b/broker/binds/containers.py
@@ -1,4 +1,6 @@
 class ContainerBind:
+    _sensitive_attrs = ["password", "host_password"]
+    
     def __init__(self, host=None, username=None, password=None, port=22, timeout=None):
         self.host = host
         self.username = username
@@ -68,7 +70,7 @@ class ContainerBind:
 
     def __repr__(self):
         inner = ", ".join(
-            f"{k}={v}"
+            f"{k}={'*' * 6 if k in self._sensitive_attrs and v else v}"
             for k, v in self.__dict__.items()
             if not k.startswith("_") and not callable(v)
         )

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -113,7 +113,7 @@ class Broker:
         method_obj = getattr(provider_inst, method)
         logger.debug(f"On {provider_inst=} executing {method_obj=} with params {self._kwargs=}.")
         result = method_obj(**self._kwargs)
-        logger.debug(logger.debug(f"Action {result=}"))
+        logger.debug(f"Action {result=}")
         if result and checkout:
             return provider_inst.construct_host(
                 provider_params=result, host_classes=self.host_classes, **self._kwargs
@@ -188,7 +188,7 @@ class Broker:
         if self._provider_actions:
             provider, _ = PROVIDER_ACTIONS[[*self._provider_actions.keys()][0]]
             logger.info(f"Querying provider {provider.__name__}")
-            self._act(provider, provider.nick_help, checkout=False)
+            self._act(provider, "nick_help", checkout=False)
 
     def _checkin(self, host):
         logger.info(f"Checking in {host.hostname or host.name}")

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -1,13 +1,27 @@
+from functools import wraps
 import signal
 import sys
 import click
 from logzero import logger
 from broker.broker import PROVIDERS, PROVIDER_ACTIONS, Broker
 from broker.providers import Provider
-from broker import exceptions, helpers, settings
+from broker.logger import LOG_LEVEL
 
 
 signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
+
+
+def loggedcli(*cli_args, **cli_kwargs):
+    def decorator(func):
+        @cli.command(*cli_args, **cli_kwargs)
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger.log(LOG_LEVEL.TRACE.value, f"Calling  {func=}(*{args=} **{kwargs=}")
+            retval = func(*args, **kwargs)
+            logger.log(LOG_LEVEL.TRACE.value, f"Finished {func=}(*{args=} **{kwargs=}) {retval=}")
+            return retval
+        return wrapper
+    return decorator
 
 
 class ExceptionHandler(click.Group):
@@ -87,7 +101,7 @@ def populate_providers(click_group):
 @click.group(cls=ExceptionHandler, invoke_without_command=True)
 @click.option(
     "--log-level",
-    type=click.Choice(["info", "warning", "error", "critical", "debug", "silent"]),
+    type=click.Choice(["info", "warning", "error", "critical", "debug", "trace", "silent"]),
     default="debug" if settings.settings.debug else "info",
     callback=helpers.update_log_level,
     is_eager=True,
@@ -119,7 +133,7 @@ def cli(version):
         click.echo(f"Log File: {broker_directory}/logs/broker.log")
 
 
-@cli.command(
+@loggedcli(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
 )
 @click.option("-b", "--background", is_flag=True, help="Run checkout in the background")
@@ -177,8 +191,7 @@ def providers():
 
 populate_providers(providers)
 
-
-@cli.command()
+@loggedcli()
 @click.argument("vm", type=str, nargs=-1)
 @click.option("-b", "--background", is_flag=True, help="Run checkin in the background")
 @click.option("--all", "all_", is_flag=True, help="Select all VMs")
@@ -217,7 +230,7 @@ def checkin(vm, background, all_, sequential, filter):
     broker_inst.checkin(sequential=sequential)
 
 
-@cli.command()
+@loggedcli()
 @click.option("--details", is_flag=True, help="Display all host details")
 @click.option(
     "--sync",
@@ -246,8 +259,7 @@ def inventory(details, sync, filter):
             logger.info(f"{num}: {display_name}")
     helpers.emit({"inventory": emit_data})
 
-
-@cli.command()
+@loggedcli()
 @click.argument("vm", type=str, nargs=-1)
 @click.option("-b", "--background", is_flag=True, help="Run extend in the background")
 @click.option("--all", "all_", is_flag=True, help="Select all VMs")
@@ -283,7 +295,7 @@ def extend(vm, background, all_, sequential, filter, **kwargs):
     broker_inst.extend(sequential=sequential)
 
 
-@cli.command()
+@loggedcli()
 @click.argument("vm", type=str, nargs=-1)
 @click.option(
     "-b", "--background", is_flag=True, help="Run duplicate in the background"
@@ -326,7 +338,7 @@ def duplicate(vm, background, count, all_, filter):
                 )
 
 
-@cli.command(
+@loggedcli(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
 )
 @click.option("-b", "--background", is_flag=True, help="Run execute in the background")

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import click
 from logzero import logger
+from broker import exceptions, helpers, settings
 from broker.broker import PROVIDERS, PROVIDER_ACTIONS, Broker
 from broker.providers import Provider
 from broker.logger import LOG_LEVEL
@@ -12,11 +13,12 @@ signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
 
 
 def loggedcli(*cli_args, **cli_kwargs):
+    """Updates the cli.command wrapper function in order to add logging"""
     def decorator(func):
         @cli.command(*cli_args, **cli_kwargs)
         @wraps(func)
         def wrapper(*args, **kwargs):
-            logger.log(LOG_LEVEL.TRACE.value, f"Calling  {func=}(*{args=} **{kwargs=}")
+            logger.log(LOG_LEVEL.TRACE.value, f"Calling {func=}(*{args=} **{kwargs=}")
             retval = func(*args, **kwargs)
             logger.log(LOG_LEVEL.TRACE.value, f"Finished {func=}(*{args=} **{kwargs=}) {retval=}")
             return retval
@@ -101,8 +103,8 @@ def populate_providers(click_group):
 @click.group(cls=ExceptionHandler, invoke_without_command=True)
 @click.option(
     "--log-level",
-    type=click.Choice(["info", "warning", "error", "critical", "debug", "trace", "silent"]),
-    default="debug" if settings.settings.debug else "info",
+    type=click.Choice(["info", "warning", "error", "debug", "trace", "silent"]),
+    default=settings.settings.logging.console_level,
     callback=helpers.update_log_level,
     is_eager=True,
     expose_value=False,

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -359,6 +359,7 @@ class MockStub(UserDict):
 
 def update_log_level(ctx, param, value):
     b_log.set_log_level(value)
+    b_log.set_file_logging(value)
 
 
 def set_emit_file(ctx, param, value):

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -358,14 +358,7 @@ class MockStub(UserDict):
 
 
 def update_log_level(ctx, param, value):
-    silent = False
-    if value == "silent":
-        silent = True
-        value = "info"
-    if getattr(logging, value.upper()) is not logger.getEffectiveLevel() or silent:
-        b_log.setup_logzero(level=value, silent=silent)
-        if not silent:
-            print(f"Log level changed to [{value}]")
+    b_log.set_log_level(value)
 
 
 def set_emit_file(ctx, param, value):

--- a/broker/logger.py
+++ b/broker/logger.py
@@ -1,10 +1,13 @@
 # -*- encoding: utf-8 -*-
 """Module handling internal and dependency logging."""
+import copy
 from enum import IntEnum
 import logging
 import logzero
 import urllib3
 from broker.settings import BROKER_DIRECTORY, settings
+from dynaconf.vendor.box.box_list import BoxList
+from dynaconf.vendor.box.box import Box
 
 import awxkit
 
@@ -13,11 +16,14 @@ class LOG_LEVEL(IntEnum):
     TRACE = 5
     DEBUG = logging.DEBUG
     INFO = logging.INFO
-    VARNING = logging.WARNING
+    WARNING = logging.WARNING
     ERROR = logging.ERROR
 
 
+_sensitive = ['password', 'pword', 'token']
+_old_factory = logging.getLogRecordFactory()
 logging.addLevelName("TRACE", LOG_LEVEL.TRACE)
+logzero.DEFAULT_COLORS[LOG_LEVEL.TRACE.value] = logzero.colors.Fore.MAGENTA
 
 
 def patch_awx_for_verbosity(api):
@@ -30,17 +36,23 @@ def patch_awx_for_verbosity(api):
         func = getattr(cls, name)
 
         def the_patch(self, *args, **kwargs):
-            awx_log.log(LOG_LEVEL.TRACE.value, f"Calling  {self=} {func=}(*{args=}, **{kwargs=}")
+            awx_log.log(
+                LOG_LEVEL.TRACE.value, f"Calling {self=} {func=}(*{args=}, **{kwargs=}"
+            )
             retval = func(self, *args, **kwargs)
-            awx_log.log(LOG_LEVEL.TRACE.value, f"Finished {self=} {func=}(*{args=}, **{kwargs=}) {retval=}")
+            awx_log.log(
+                LOG_LEVEL.TRACE.value,
+                f"Finished {self=} {func=}(*{args=}, **{kwargs=}) {retval=}",
+            )
             return retval
+
         setattr(cls, name, the_patch)
 
     for method in "delete get head options patch post put".split():
         patch(api.Connection, method)
 
 
-def resolve_log_level(level) -> LOG_LEVEL:
+def resolve_log_level(level):
     try:
         log_level = LOG_LEVEL[level.upper()]
     except KeyError:
@@ -48,40 +60,81 @@ def resolve_log_level(level) -> LOG_LEVEL:
     return log_level
 
 
-def formatter_factory(log_level):
+def formatter_factory(log_level, color=True):
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
     debug_fmt = (
         "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"
         "%(end_color)s %(message)s"
     )
     formatter = logzero.LogFormatter(
-        fmt=debug_fmt if log_level <= LOG_LEVEL.DEBUG else log_fmt
+        fmt=debug_fmt if log_level <= LOG_LEVEL.DEBUG else log_fmt, color=color
     )
     return formatter
 
+def record_factory(*args, **kwargs):
+    """Factory to create a redacted logging.LogRecord"""
+    record = _old_factory(*args, **kwargs)
+    args_new = []
+    for arg in record.args:
+        if isinstance(arg, (tuple, Box, BoxList)):
+            args_new.append(redact_dynaconf(arg))
+        else:
+            args_new.append(arg)
+    record.args = tuple(args_new)
+    return record
 
-def set_log_level(level: str):
+def redact_dynaconf(data):
+    if isinstance(data, (list, tuple)):
+        data_copy = [redact_dynaconf(item) for item in data]
+    elif isinstance(data, dict):
+        data_copy = copy.deepcopy(data)
+        for k, v in data_copy.items():
+            if isinstance(v, (dict, list)):
+                data_copy[k] = redact_dynaconf(v)
+            elif k in _sensitive and v:
+                data_copy[k] = '*' * 6
+    else:
+        data_copy = data
+    return data_copy
+
+
+def set_log_level(level=settings.logging.console_level):
     silent = False
     if level == "silent":
         silent = True
         log_level = LOG_LEVEL.INFO
-
-    log_level = resolve_log_level(level)
-    logzero.setup_default_logger(level=log_level, formatter=formatter_factory(log_level), disableStderrLogger=silent)
-    set_file_logging(log_level)
-    if log_level is not logzero.logger.getEffectiveLevel() or silent:
-        if not silent:
-            print(f"Log level changed to [{log_level.name}]")
-
-
-def set_file_logging(log_level=LOG_LEVEL.INFO, path="logs/broker.log"):
-    path = BROKER_DIRECTORY.joinpath(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    logzero.logfile(
-        path, loglevel=log_level.value, maxBytes=1e9, backupCount=3, formatter=formatter_factory(log_level), color=False
+    else:
+        log_level = resolve_log_level(level)
+    logzero.setup_default_logger(
+        level=log_level,
+        formatter=formatter_factory(log_level),
+        disableStderrLogger=silent,
     )
 
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-patch_awx_for_verbosity(awxkit.api)
-set_file_logging()
+def set_file_logging(level=settings.logging.file_level, path="logs/broker.log"):
+    log_level = resolve_log_level(level)
+    path = BROKER_DIRECTORY.joinpath(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    logzero.logfile(
+        path,
+        loglevel=log_level.value,
+        maxBytes=1e9,
+        backupCount=3,
+        formatter=formatter_factory(log_level, color=False),
+    )
+
+
+def setup_logzero(
+    level=settings.logging.console_level,
+    file_level=settings.logging.file_level,
+    path="logs/broker.log",
+):
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    patch_awx_for_verbosity(awxkit.api)
+    set_log_level(level)
+    set_file_logging(file_level, path)
+    logging.setLogRecordFactory(record_factory)
+
+
+setup_logzero()

--- a/broker/logger.py
+++ b/broker/logger.py
@@ -1,34 +1,87 @@
 # -*- encoding: utf-8 -*-
 """Module handling internal and dependency logging."""
+from enum import IntEnum
 import logging
 import logzero
 import urllib3
 from broker.settings import BROKER_DIRECTORY, settings
 
+import awxkit
 
-def setup_logzero(level="info", path="logs/broker.log", silent=False):
-    path = BROKER_DIRECTORY.joinpath(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+
+class LOG_LEVEL(IntEnum):
+    TRACE = 5
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    VARNING = logging.WARNING
+    ERROR = logging.ERROR
+
+
+logging.addLevelName("TRACE", LOG_LEVEL.TRACE)
+
+
+def patch_awx_for_verbosity(api):
+    client = api.client
+    awx_log = client.log
+
+    awx_log.parent = logzero.logger
+
+    def patch(cls, name):
+        func = getattr(cls, name)
+
+        def the_patch(self, *args, **kwargs):
+            awx_log.log(LOG_LEVEL.TRACE.value, f"Calling  {self=} {func=}(*{args=}, **{kwargs=}")
+            retval = func(self, *args, **kwargs)
+            awx_log.log(LOG_LEVEL.TRACE.value, f"Finished {self=} {func=}(*{args=}, **{kwargs=}) {retval=}")
+            return retval
+        setattr(cls, name, the_patch)
+
+    for method in "delete get head options patch post put".split():
+        patch(api.Connection, method)
+
+
+def resolve_log_level(level) -> LOG_LEVEL:
+    try:
+        log_level = LOG_LEVEL[level.upper()]
+    except KeyError:
+        log_level = LOG_LEVEL.INFO
+    return log_level
+
+
+def formatter_factory(log_level):
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
     debug_fmt = (
         "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"
         "%(end_color)s %(message)s"
     )
-    log_level = getattr(logging, level.upper(), logging.INFO)
-    # formatter for terminal
     formatter = logzero.LogFormatter(
-        fmt=debug_fmt if log_level is logging.DEBUG else log_fmt
+        fmt=debug_fmt if log_level <= LOG_LEVEL.DEBUG else log_fmt
     )
-    logzero.setup_default_logger(formatter=formatter, disableStderrLogger=silent)
-    logzero.loglevel(log_level)
-    # formatter for file
-    formatter = logzero.LogFormatter(
-        fmt=debug_fmt if log_level is logging.DEBUG else log_fmt, color=False
-    )
+    return formatter
+
+
+def set_log_level(level: str):
+    silent = False
+    if level == "silent":
+        silent = True
+        log_level = LOG_LEVEL.INFO
+
+    log_level = resolve_log_level(level)
+    logzero.setup_default_logger(level=log_level, formatter=formatter_factory(log_level), disableStderrLogger=silent)
+    set_file_logging(log_level)
+    if log_level is not logzero.logger.getEffectiveLevel() or silent:
+        if not silent:
+            print(f"Log level changed to [{log_level.name}]")
+
+
+def set_file_logging(log_level=LOG_LEVEL.INFO, path="logs/broker.log"):
+    path = BROKER_DIRECTORY.joinpath(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     logzero.logfile(
-        path, loglevel=log_level, maxBytes=1e9, backupCount=3, formatter=formatter
+        path, loglevel=log_level.value, maxBytes=1e9, backupCount=3, formatter=formatter_factory(log_level), color=False
     )
 
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-setup_logzero(level="debug" if settings.debug else "info")
+patch_awx_for_verbosity(awxkit.api)
+set_file_logging()

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -17,6 +17,7 @@ class Provider(PickleSafe):
     _checkout_options = []
     _execute_options = []
     _fresh_settings = settings.dynaconf_clone()
+    _sensitive_attrs = []
 
     def __init__(self, **kwargs):
         self._construct_params = []
@@ -40,7 +41,7 @@ class Provider(PickleSafe):
         fresh_settings = self._fresh_settings.get(section_name).copy()
         instance, default = None, False
         for candidate in fresh_settings.instances:
-            logger.debug(f"Checking {instance_name} against {candidate}")
+            logger.debug("Checking %s against %s", instance_name, candidate)
             if instance_name in candidate:
                 instance = candidate
                 default = False
@@ -95,7 +96,7 @@ class Provider(PickleSafe):
 
     def __repr__(self):
         inner = ", ".join(
-            f"{k}={v}"
+            f"{k}={'*' * 6 if k in self._sensitive_attrs and v else v}"
             for k, v in self.__dict__.items()
             if not k.startswith("_") and not callable(v)
         )

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -127,6 +127,8 @@ class AnsibleTower(Provider):
         ),
     ]
 
+    _sensitive_attrs = ['pword', 'password', 'token']
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # get our instance settings
@@ -626,14 +628,6 @@ class AnsibleTower(Provider):
             source_vm=name,
             **broker_args,
         )
-
-    def __repr__(self):
-        inner = ", ".join(
-            f"{k}={v}"
-            for k, v in self.__dict__.items()
-            if not k.startswith("_") and not callable(v)
-        )
-        return f"{self.__class__.__name__}({inner})"
 
 
 def awxkit_representer(dumper, data):

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -74,6 +74,8 @@ class Container(Provider):
     ]
     _extend_options = []
 
+    _sensitive_attrs = ["password", "host_password"]
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if kwargs.get("bind") is not None:

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -21,9 +21,12 @@ validators = [
     Validator("HOST_CONNECTION_TIMEOUT", default=None),
     Validator("HOST_SSH_PORT", default=22),
     Validator("HOST_SSH_KEY_FILENAME", default=None),
+    Validator("LOGGING", is_type_of=dict),
+    Validator("LOGGING.LEVEL", is_in=["error", "warning", "info", "debug", "trace", "silent"], default="info"),
+    Validator("LOGGING.FILE_LEVEL", is_in=["error", "warning", "info", "debug", "trace", "silent"], default="debug"),
 ]
 
-# temportary fix for dynaconf #751
+# temporary fix for dynaconf #751
 vault_vars = {k: v for k, v in os.environ.items() if "VAULT_" in k}
 for k in vault_vars:
     del os.environ[k]

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,5 +1,8 @@
 # Broker settings
-debug: False
+# different log levels for file and stdout
+logging:
+    console_level: info
+    file_level: debug
 inventory_file: "inventory.yaml"
 # Host Settings
 host_username: "root"


### PR DESCRIPTION
## Description
This PR is a rebase of #126 onto the current `master`.

### Description of the original PR

* Dedup update_provider_action.
* Log the click commands
* Monkeypatch the awxkit to be more verbose
* Add log messages

### Additional additions/fixes by @ogajduse 

* defined `setup_logzero` function to keep compatibility with logging setup in robottelo
* changed the way logging is configured - potential breaking change `settings.debug` option will not exist anymore. Users will have to adopt the new config format.
* added colors to the TRACE level messages
* redacted sensitive attributes from broker logs
* fixed a typo :stuck_out_tongue: 

## Test results

* TODO