### PR TITLE
[0.3.0] Refactor Provider registration system

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -1,28 +1,12 @@
 from logzero import logger
-from broker.providers.ansible_tower import AnsibleTower
-from broker.providers.container import Container
-from broker.providers.test_provider import TestProvider
+from broker.providers import PROVIDERS, PROVIDER_ACTIONS, _provider_imports
 from broker.hosts import Host
 from broker import exceptions, helpers
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-
-PROVIDERS = {
-    "AnsibleTower": AnsibleTower,
-    "Container": Container,
-    "TestProvider": TestProvider,
-}
-
-PROVIDER_ACTIONS = {
-    # action: (InterfaceClass, "method_name")
-    "workflow": (AnsibleTower, "execute"),
-    "job_template": (AnsibleTower, "execute"),
-    "template": (AnsibleTower, None),  # needed for list-templates
-    "inventory": (AnsibleTower, None),
-    "container_host": (Container, "run_container"),
-    "container_app": (Container, "execute"),
-    "test_action": (TestProvider, "test_action"),
-}
+# load all the provider class so they are registered
+for _import in _provider_imports:
+    __import__(f"broker.providers.{_import}", globals(), locals(), [], 0)
 
 
 def _try_teardown(host_obj):

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -5,8 +5,8 @@ import click
 from logzero import logger
 from broker import exceptions, helpers, settings
 from broker.broker import PROVIDERS, PROVIDER_ACTIONS, Broker
-from broker.providers import Provider
 from broker.logger import LOG_LEVEL
+from broker import exceptions, helpers, settings
 
 
 signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
@@ -50,7 +50,7 @@ class ExceptionHandler(click.Group):
 
 def provider_options(command):
     """Applies provider-specific decorators to each command this decorates"""
-    for prov in Provider.__subclasses__():
+    for prov in PROVIDERS.values():
         if prov.hidden:
             continue
         for option in getattr(prov, f"_{command.__name__}_options"):

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -533,4 +533,3 @@ def temporary_tar(paths):
             tar.add(path, arcname=path.name)
     yield temp_tar.absolute()
     temp_tar.unlink()
-

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -459,6 +459,7 @@ class AnsibleTower(Provider):
         self._set_attributes(host_inst, broker_args=kwargs, misc_attrs=misc_attrs)
         return host_inst
 
+    @Provider.register_action("workflow", "job_template")
     def execute(self, **kwargs):
         """Execute workflow or job template in Ansible Tower
 
@@ -568,6 +569,7 @@ class AnsibleTower(Provider):
             or settings.ANSIBLETOWER.get("new_expire_time"),
         )
 
+    @Provider.register_action("template", "inventory")
     def nick_help(self, **kwargs):
         """Get a list of extra vars and their defaults from a workflow"""
         results_limit = kwargs.get("results_limit", settings.ANSIBLETOWER.results_limit)

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -252,6 +252,7 @@ class Container(Provider):
     def release(self, host_obj):
         host_obj._cont_inst.remove(force=True)
 
+    @Provider.register_action("container_host")
     def run_container(self, container_host, **kwargs):
         """Start a container based on an image name (container_host)"""
         self._ensure_image(container_host)
@@ -276,6 +277,7 @@ class Container(Provider):
         container_inst.start()
         return container_inst
 
+    @Provider.register_action("container_app")
     def execute(self, container_app, **kwargs):
         """Run a container and return the raw results"""
         return self.runtime.execute(container_app, **kwargs)

--- a/broker/providers/test_provider.py
+++ b/broker/providers/test_provider.py
@@ -46,6 +46,7 @@ class TestProvider(Provider):
         self._set_attributes(host_inst, broker_args=kwargs)
         return host_inst
 
+    @Provider.register_action()
     def test_action(self, **kwargs):
         action = kwargs.get("test_action")
         if action == "release":


### PR DESCRIPTION
This new version is more in-line with a plugin-based approach.
A Provider author can now create a new Provider class and register it
without having to touch any other files but their own.

To do this, we now have automatic registration of any class that inherits
from the base Provider class. Additionally, registering actions is done via
a new decorator.

Also

Remove PickleSafe base class
Broker has moved from multiprocessing to multithreading for concurrency.
Because of this, we no longer have to worry about pickling objects.