### PR TITLE
Logging improvements & fixes

### DIFF
--- a/broker/binds/containers.py
+++ b/broker/binds/containers.py
@@ -1,6 +1,6 @@
 class ContainerBind:
     _sensitive_attrs = ["password", "host_password"]
-    
+
     def __init__(self, host=None, username=None, password=None, port=22, timeout=None):
         self.host = host
         self.username = username

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -111,7 +111,9 @@ class Broker:
             }
         )
         method_obj = getattr(provider_inst, method)
-        logger.debug(f"On {provider_inst=} executing {method_obj=} with params {self._kwargs=}.")
+        logger.debug(
+            f"On {provider_inst=} executing {method_obj=} with params {self._kwargs=}."
+        )
         result = method_obj(**self._kwargs)
         logger.debug(f"Action {result=}")
         if result and checkout:

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -14,15 +14,21 @@ signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
 
 def loggedcli(*cli_args, **cli_kwargs):
     """Updates the cli.command wrapper function in order to add logging"""
+
     def decorator(func):
         @cli.command(*cli_args, **cli_kwargs)
         @wraps(func)
         def wrapper(*args, **kwargs):
             logger.log(LOG_LEVEL.TRACE.value, f"Calling {func=}(*{args=} **{kwargs=}")
             retval = func(*args, **kwargs)
-            logger.log(LOG_LEVEL.TRACE.value, f"Finished {func=}(*{args=} **{kwargs=}) {retval=}")
+            logger.log(
+                LOG_LEVEL.TRACE.value,
+                f"Finished {func=}(*{args=} **{kwargs=}) {retval=}",
+            )
             return retval
+
         return wrapper
+
     return decorator
 
 
@@ -135,9 +141,7 @@ def cli(version):
         click.echo(f"Log File: {broker_directory}/logs/broker.log")
 
 
-@loggedcli(
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
-)
+@loggedcli(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @click.option("-b", "--background", is_flag=True, help="Run checkout in the background")
 @click.option("-n", "--nick", type=str, help="Use a nickname defined in your settings")
 @click.option(
@@ -192,6 +196,7 @@ def providers():
 
 
 populate_providers(providers)
+
 
 @loggedcli()
 @click.argument("vm", type=str, nargs=-1)
@@ -260,6 +265,7 @@ def inventory(details, sync, filter):
         else:
             logger.info(f"{num}: {display_name}")
     helpers.emit({"inventory": emit_data})
+
 
 @loggedcli()
 @click.argument("vm", type=str, nargs=-1)
@@ -340,9 +346,7 @@ def duplicate(vm, background, count, all_, filter):
                 )
 
 
-@loggedcli(
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
-)
+@loggedcli(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @click.option("-b", "--background", is_flag=True, help="Run execute in the background")
 @click.option("--nick", type=str, help="Use a nickname defined in your settings")
 @click.option(

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -127,7 +127,7 @@ class AnsibleTower(Provider):
         ),
     ]
 
-    _sensitive_attrs = ['pword', 'password', 'token']
+    _sensitive_attrs = ["pword", "password", "token"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -22,8 +22,16 @@ validators = [
     Validator("HOST_SSH_PORT", default=22),
     Validator("HOST_SSH_KEY_FILENAME", default=None),
     Validator("LOGGING", is_type_of=dict),
-    Validator("LOGGING.LEVEL", is_in=["error", "warning", "info", "debug", "trace", "silent"], default="info"),
-    Validator("LOGGING.FILE_LEVEL", is_in=["error", "warning", "info", "debug", "trace", "silent"], default="debug"),
+    Validator(
+        "LOGGING.CONSOLE_LEVEL",
+        is_in=["error", "warning", "info", "debug", "trace", "silent"],
+        default="info",
+    ),
+    Validator(
+        "LOGGING.FILE_LEVEL",
+        is_in=["error", "warning", "info", "debug", "trace", "silent"],
+        default="debug",
+    ),
 ]
 
 # temporary fix for dynaconf #751


### PR DESCRIPTION
* formatted logging related code using black
* removed deprecated logzero.setup_default_logger
  * broken down into logzero.formatter, logzero.loglevel and logzero.logfile
* fixed broken logging in ipython console with %autoreload 2 turned on
  * _old_factory is None by default and is set to `broker_record_factory` only if _old_factory was not set to `broker_record_factory` yet.