### PR TITLE
[0.3.0] Make Broker more opinionated about where its files are located

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Unit Tests
+      env:
+        BROKER_DIRECTORY: ${{ github.workspace }}
       run: |
         pip install -U pip
         pip install -U .[test,docker]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Broker is a tool designed to provide a common interface between one or many serv
 dnf install cmake
 cd <broker root directory>
 
-pip install .   ( install Broker cloned locally )   
-or   
+pip install .   ( install Broker cloned locally )
+or
 pip install broker   ( install latest version from PyPI )
 
 cp broker_settings.yaml.example broker_settings.yaml
@@ -29,19 +29,19 @@ pip install broker[docker]
 ```
 These may not work correctly in non-bash environments.
 
-Broker can also be ran outside of its base directory. In order to do so, specify the directory broker's files are in with the
+By default, Broker's base directory will be located at `.broker/` in your home directory. In order to run from another location, specify the directory Broker's files are in with the
 `BROKER_DIRECTORY` envronment variable.
-```BROKER_DIRECTORY=/home/jake/Programming/broker/ broker inventory```
+```export BROKER_DIRECTORY=/home/jake/Programming/broker/```
 
-# Installation MacOS 12.x 
+# Installation MacOS 12.x
 ```
 brew install cmake
 brew install openssl
 brew install libssh2
 cd <broker root directory>
 
-pip install .   ( install Broker cloned locally )   
-or   
+pip install .   ( install Broker cloned locally )
+or
 pip install broker   ( install latest version from PyPI )
 
 cp broker_settings.yaml.example broker_settings.yaml
@@ -57,7 +57,7 @@ $ PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L$(brew --prefix openssl)/lib" CPPFLAGS="
 Error: If libsshX.Y.dylib cannot be found, follow the additional steps:
 
 - Locate the .dylib files from within libssh2 (likely in `/opt/homebrew/Cellar/` or `/usr/lib/`)
-- Export the path to the .dylibs directory as the 
+- Export the path to the .dylibs directory as the
 `DYLD_LIBRARY_PATH` environment variable;
 
 ```export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/libssh2/1.10.0/lib/```
@@ -110,7 +110,7 @@ If you have more complex data structures you need to pass in, you can do that in
 You can populate a json or yaml file where the top-level keys will become broker arguments and their nested data structures become values.
 Note:
     The json and yaml files need to use the supported suffix ('json', 'yaml', '.yml') in order to be properly recognized.
-    Any eventual arbitrary arguments passed to CLI will be combined with those in the passed argument file with the CLI ones taking precedence.  
+    Any eventual arbitrary arguments passed to CLI will be combined with those in the passed argument file with the CLI ones taking precedence.
 ```
 broker checkout --nick rhel7 --args-file tests/data/broker_args.json
 ```

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 import getpass
 import inspect
 import json
-import logging
 import os
 import pickle
 import sys
@@ -212,10 +211,7 @@ def load_inventory(filter=None):
 
     :return: list of dictionaries
     """
-    inventory_file = settings.BROKER_DIRECTORY.joinpath(
-        settings.settings.INVENTORY_FILE
-    )
-    inv_data = load_file(inventory_file, warn=False)
+    inv_data = load_file(settings.inventory_path, warn=False)
     return inv_data if not filter else inventory_filter(inv_data, filter)
 
 
@@ -228,19 +224,16 @@ def update_inventory(add=None, remove=None):
 
     :return: no return value
     """
-    inventory_file = settings.BROKER_DIRECTORY.joinpath(
-        settings.settings.INVENTORY_FILE
-    )
     if add and not isinstance(add, list):
         add = [add]
     elif not add:
         add = []
     if remove and not isinstance(remove, list):
         remove = [remove]
-    with FileLock(inventory_file):
+    with FileLock(settings.inventory_path):
         inv_data = load_inventory()
         if inv_data:
-            inventory_file.unlink()
+            settings.inventory_path.unlink()
 
         if remove:
             for host in inv_data[::-1]:
@@ -257,8 +250,8 @@ def update_inventory(add=None, remove=None):
         if add:
             inv_data.extend(add)
 
-        inventory_file.touch()
-        with inventory_file.open("w") as inv_file:
+        settings.inventory_path.touch()
+        with settings.inventory_path.open("w") as inv_file:
             yaml.dump(inv_data, inv_file)
 
 

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -4,20 +4,22 @@ from dynaconf import Dynaconf, Validator
 from dynaconf.validator import ValidationError
 from broker.exceptions import ConfigurationError
 
-settings_file = "broker_settings.yaml"
-BROKER_DIRECTORY = Path()
+BROKER_DIRECTORY = Path.home().joinpath(".broker")
 
 if "BROKER_DIRECTORY" in os.environ:
     envar_location = Path(os.environ["BROKER_DIRECTORY"])
     if envar_location.is_dir():
         BROKER_DIRECTORY = envar_location
 
+# ensure the broker directory exists
+BROKER_DIRECTORY.mkdir(parents=True, exist_ok=True)
+
 settings_path = BROKER_DIRECTORY.joinpath("broker_settings.yaml")
 inventory_path = BROKER_DIRECTORY.joinpath("inventory.yaml")
 
 validators = [
     Validator("HOST_USERNAME", default="root"),
-    Validator("HOST_PASSWORD", must_exist=True),
+    Validator("HOST_PASSWORD", default="toor"),
     Validator("HOST_CONNECTION_TIMEOUT", default=None),
     Validator("HOST_SSH_PORT", default=22),
     Validator("HOST_SSH_KEY_FILENAME", default=None),

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -3,7 +3,6 @@
 logging:
     console_level: info
     file_level: debug
-inventory_file: "inventory.yaml"
 # Host Settings
 # These can be left alone if you're not using Broker as a library
 host_username: "root"


### PR DESCRIPTION
This change creates a new standard for where Broker files are located. By default, Broker will be based in ~/.broker/ but will still listen for the BROKER_DIRECTORY environment variable.

As a result, Broker will no longer honor any alternative locations for its inventory file.

Fixes #190