### PR TITLE
Delete property only if it exists

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -550,7 +550,8 @@ class AnsibleTower(Provider):
         if new_inv := target_vm._broker_args.get("tower_inventory"):
             if new_inv != self._inventory:
                 self._inventory = new_inv
-                del self.inventory  # clear the cached value
+                if hasattr(self.__dict__, 'inventory'):
+                    del self.inventory  # clear the cached value
         return self.execute(
             workflow=settings.ANSIBLETOWER.extend_workflow,
             target_vm=target_vm.name,


### PR DESCRIPTION
fixes #199

In case when `VM inventory != default inventory`:
Broker tries to delete the `inventory` attribute (cached_property)  even though it is not evaluated yet. That results in `'AnsibleTower' object has no attribute 'inventory'`

I propose to check whether it was evaluated using `__dict__` first and then safely delete it.