### PR TITLE
Make inventory syncs more resilient to data loss

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -309,9 +309,8 @@ class Broker:
             instance = {provider: instance}
         prov_inventory = PROVIDERS[provider](**instance).get_inventory(additional_arg)
         curr_inventory = [
-            host.get("hostname", host.get("name"))
-            for host in helpers.load_inventory()
-            if host["_broker_provider"] == provider
+            hostname if (hostname := host.get("hostname")) else host.get("name")
+            for host in helpers.load_inventory(filter=f"_broker_provider={provider}")
         ]
         helpers.update_inventory(add=prov_inventory, remove=curr_inventory)
 

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -253,7 +253,7 @@ class Broker:
         logger.info(f"Extending host {host.hostname}")
         provider = PROVIDERS[host._broker_provider]
         self._kwargs["target_vm"] = host
-        self._act(provider, "extend_vm", checkout=False)
+        self._act(provider, "extend", checkout=False)
         return host
 
     def extend(self, sequential=False, host=None):

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -233,7 +233,7 @@ def update_inventory(add=None, remove=None):
     )
     if add and not isinstance(add, list):
         add = [add]
-    else:
+    elif not add:
         add = []
     if remove and not isinstance(remove, list):
         remove = [remove]

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -29,37 +29,38 @@ class Provider(PickleSafe):
     def _validate_settings(self, instance_name=None):
         """Load and validate provider settings
 
-        Each provider's settings must include an instances list with specific instance
+        Each provider's settings can include an instances list with specific instance
         details.
+        One instance should have a "default" key set to True, if instances are defined.
         General provider settings should live on the top level for that provider.
-        One instance should have a "default" key set to True
 
         :param instance_name: A string matching an instance name
         """
-        instance_name = instance_name or getattr(self, "instance", None)
         section_name = self.__class__.__name__.upper()
-        fresh_settings = self._fresh_settings.get(section_name).copy()
-        instance, default = None, False
-        for candidate in fresh_settings.instances:
-            logger.debug("Checking %s against %s", instance_name, candidate)
-            if instance_name in candidate:
-                instance = candidate
-                default = False
-                break
-            elif (
-                candidate.values()[0].get("default")
-                or len(fresh_settings.instances) == 1
-            ):
-                instance = candidate
-                default = True
-        self.instance, *_ = instance  # store the instance name on the provider
-        fresh_settings.update(instance.values()[0])
-        settings[section_name] = fresh_settings
-        if default:
-            # if a default provider is selected, defer to loaded environment variables
-            settings.execute_loaders(loaders=[dynaconf.loaders.env_loader])
+        # if the provider has instances, load the instance settings
+        if self._fresh_settings.get(section_name).get("instances"):
+            fresh_settings = self._fresh_settings.get(section_name).copy()
+            instance_name = instance_name or getattr(self, "instance", None)
+            # iterate through the instances and find the one that matches the instance_name
+            # if no instance matches, use the default instance
+            for candidate in fresh_settings.instances:
+                logger.debug("Checking %s against %s", instance_name, candidate)
+                if instance_name in candidate:
+                    instance = candidate
+                    break
+                elif (
+                    candidate.values()[0].get("default")
+                    or len(fresh_settings.instances) == 1
+                ):
+                    instance = candidate
+            self.instance, *_ = instance  # store the instance name on the provider
+            fresh_settings.update((inst_vals := instance.values()[0]))
+            settings[section_name] = fresh_settings
+            if not inst_vals.get("override_envars"):
+                # if a provider instance doesn't want to override envars, load them
+                settings.execute_loaders(loaders=[dynaconf.loaders.env_loader])
 
-        settings.validators.extend(self._validators)
+        settings.validators.extend([v for v in self._validators if v not in settings.validators])
         # use selective validation to only validate the instance settings
         try:
             settings.validators.validate(only=section_name)

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -393,6 +393,9 @@ class AnsibleTower(Provider):
                 if val and isinstance(val, str)
             }
         )
+        # temporary workaround for OSP hosts that have lost their hostname
+        if not host_info["hostname"] and host.variables.get("openstack"):
+            host_info["hostname"] = host.variables["openstack"]["metadata"].get("fqdn")
         return host_info
 
     @cached_property

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -57,6 +57,7 @@ TestProvider:
             default: True
         - test2:
             foo: "baz"
+            override_envars: True
         - bad:
             nothing: False
     config_value: "something"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -55,9 +55,9 @@ def test_nondefault_envar(set_envars):
     """Set a top-level instance value via environment variable
     then verify that the value has been overriden when the provider is specified.
     """
-    test_provider = TestProvider(TestProvider="test1")
-    assert test_provider.instance == "test1"
-    assert test_provider.foo == "bar"
+    test_provider = TestProvider(TestProvider="test2")
+    assert test_provider.instance == "test2"
+    assert test_provider.foo == "baz"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We're currently seeing an issue with data loss in OSP hosts from AAP. This commit introduces a couple of ways around this.
1. Try to recover the fqdn from the openstack metadata in host variables, if present.
2. Inventory sync are now non-destructive for data within a host.

Second commit adds a few fixes

Third commit introduces some changes to the way instances are evaluated. It makes instances optional and allows for each instance to specify whether or not it can override envars set at the Provider level.
Fixes #195
Fixes #198
Fixes #184