### PR TITLE
[0.3.0] Add the ability for Broker to download a missing settings file

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,12 @@ on:
     branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "*.md"
+      - "*.example"
+      - ".gitignore"
+      - "tests/functional/*"
+      - "tests/data/*"
 
 jobs:
   analyze:
@@ -17,27 +23,31 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Unit Tests
-      env:
-        BROKER_DIRECTORY: ${{ github.workspace }}
-      run: |
-        pip install -U pip
-        pip install -U .[test,docker]
-        cp broker_settings.yaml.example broker_settings.yaml
-        pytest -v tests/ --ignore tests/functional
+      - name: Setup Temp Directory
+        run: mkdir broker_dir
+
+      - name: Unit Tests
+        env:
+          BROKER_DIRECTORY: "${{ github.workspace }}/broker_dir"
+        run: |
+          pip install -U pip
+          pip install -U .[test,docker]
+          ls -l "$BROKER_DIRECTORY"
+          broker --version
+          pytest -v tests/ --ignore tests/functional

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -149,6 +149,23 @@ def cli(version):
         import pkg_resources
 
         broker_version = pkg_resources.get_distribution("broker").version
+        # check the latest version publish to PyPi
+        try:
+            import requests
+            from packaging.version import Version
+
+            latest_version = Version(
+                requests.get("https://pypi.org/pypi/broker/json").json()["info"][
+                    "version"
+                ]
+            )
+            if latest_version > Version(broker_version):
+                click.secho(
+                    f"A newer version of broker is available: {latest_version}",
+                    fg="yellow",
+                )
+        except:
+            pass
         click.echo(f"Version: {broker_version}")
         broker_directory = settings.BROKER_DIRECTORY.absolute()
         click.echo(f"Broker Directory: {broker_directory}")

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-
-setup(
-    use_scm_version=True,
-)
+setup(use_scm_version=True)


### PR DESCRIPTION
When the settings file is missing from the user's Broker directory,
Broker will prompt them to download the file from GitHub and open an editor.