### PR TITLE
Simplify broker_settings.yaml.example

### DIFF
--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -11,22 +11,13 @@ host_ssh_port: "<port>"
 host_ssh_key_filename: "</path/to/the/ssh-key>"
 # Provider settings
 AnsibleTower:
-    instances:
-        - production:
-            base_url: "https://<ansible tower host>/"
-            # Username AND password, OR an OAUTH token can be used for authentication
-            username: "<username>"
-            password: "<plain text password>"
-            # token: "<AT personal access token>"
-            inventory: "inventory name"
-            default: True
-        - testing:
-            base_url: "https://<ansible tower host>/"
-            # Username AND password, OR an OAUTH token can be used for authentication
-            username: "<username>"
-            password: "<plain text password>"
-            # token: "<AT personal access token>"
-            inventory: "inventory name"
+    base_url: "https://<ansible tower host>/"
+    # Username is required for both token and password-based authentication
+    username: "<username>"
+    # token is the preferred authentication method
+    token: "<AT personal access token>"
+    # password: "<plain text password>"
+    inventory: "inventory name"
     release_workflow: "remove-vm"
     extend_workflow: "extend-vm"
     new_expire_time: "+172800"

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -5,9 +5,9 @@ logging:
     file_level: debug
 # Host Settings
 # These can be left alone if you're not using Broker as a library
-host_username: "root"
+host_username: root
 host_password: "<password>"
-host_ssh_port: "<port>"
+host_ssh_port: 22
 host_ssh_key_filename: "</path/to/the/ssh-key>"
 # Provider settings
 AnsibleTower:


### PR DESCRIPTION
This simplifies and clarifies the AnsibleTower provider's example settings.

I think more can be done here in the future around removing the test settings, but that's beyond this update.