### PR TITLE
Add contextual awareness to host creation

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -16,7 +16,12 @@ class Host:
         else:
             self.hostname = hostname or kwargs.get("ip", None)
             if not self.hostname:
-                raise HostError("Host must be constructed with a hostname or ip")
+                # check to see if we're being reconstructued, likely for checkin
+                import inspect
+                if any(f.function == "reconstruct_host" for f in inspect.stack()):
+                    logger.debug("Ignoring missing hostname and ip for checkin reconstruction.")
+                else:
+                    raise HostError("Host must be constructed with a hostname or ip")
             self.name = name
         self.username = kwargs.get("username", settings.HOST_USERNAME)
         self.password = kwargs.get("password", settings.HOST_PASSWORD)

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -89,8 +89,9 @@ class Provider(metaclass=ProviderMeta):
             if not inst_vals.get("override_envars"):
                 # if a provider instance doesn't want to override envars, load them
                 settings.execute_loaders(loaders=[dynaconf.loaders.env_loader])
-
-        settings.validators.extend([v for v in self._validators if v not in settings.validators])
+        new_validators = [v for v in self._validators if v not in settings.validators]
+        logger.debug(f"Adding new validators: {[v.names[0] for v in new_validators]}")
+        settings.validators.extend(new_validators)
         # use selective validation to only validate the instance settings
         try:
             settings.validators.validate(only=section_name)

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -549,7 +549,9 @@ class AnsibleTower(Provider):
         for inv in invs:
             inv_hosts = inv.get_related("hosts", page_size=200).results
             hosts.extend(inv_hosts)
-        return [self._compile_host_info(host) for host in hosts]
+        with click.progressbar(hosts, label='Compiling host information') as hosts_bar:
+            compiled_host_info = [self._compile_host_info(host) for host in hosts_bar]
+        return compiled_host_info
 
     def extend(self, target_vm, new_expire_time=None):
         """Run the extend workflow with defaults args

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -212,7 +212,7 @@ class Container(Provider):
 
     def nick_help(self, **kwargs):
         """Useful information about container images"""
-        results_limit = kwargs.get("results_limit", settings.CONTAINER.results_limit)
+        results_limit = kwargs.get("results_limit", settings.container.results_limit)
         if image := kwargs.get("container_host"):
             logger.info(
                 f"Information for {image} container-host:\n"


### PR DESCRIPTION
This change fixes an issue we're seeing where host entries, missing a hostname and ip, are being reconstructed for checkin. While that shouldn't be an issue during checkin, it would be if used for other purposes.

With that in mind, this adds a check to see if the host is being reconstructed. If so, then it will just debug log instead of raising an error.

Add in some new workarounds and log statements
We're seeing some strange behavior in CI. These are attempts to solve them
and/or get more information about what's going on.