### PR TITLE
refactor logging

### DIFF
--- a/broker/__init__.py
+++ b/broker/__init__.py
@@ -1,3 +1,3 @@
-from broker.broker import Broker
+#from broker.broker import Broker
 
-VMBroker = Broker
+#VMBroker = Broker

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -1,8 +1,10 @@
-from logzero import logger
 from broker.providers import PROVIDERS, PROVIDER_ACTIONS, _provider_imports
 from broker.hosts import Host
 from broker import exceptions, helpers
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from logging import getLogger
+
+logger = getLogger('broker')
 
 # load all the provider class so they are registered
 for _import in _provider_imports:

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -2,12 +2,14 @@ from functools import wraps
 import signal
 import sys
 import click
-from logzero import logger
+from logging import getLogger
 from broker import exceptions, helpers, settings
 from broker.broker import PROVIDERS, PROVIDER_ACTIONS, Broker
 from broker.logger import LOG_LEVEL
 from broker import exceptions, helpers, settings
 
+logger = getLogger(__name__)
+logger.propagate = True
 
 signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
 

--- a/broker/exceptions.py
+++ b/broker/exceptions.py
@@ -1,5 +1,8 @@
 """A collection of Broker-specific exceptions"""
-from logzero import logger
+from logging import getLogger
+
+logger = getLogger(__name__)
+logger.propagate = True
 
 
 class BrokerError(Exception):

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -15,10 +15,13 @@ from pathlib import Path
 from uuid import uuid4
 
 import yaml
-from logzero import logger
+from logging import getLogger
 
 from broker import exceptions, settings
 from broker import logger as b_log
+
+logger = getLogger(__name__)
+logger.propagate = True
 
 FilterTest = namedtuple("FilterTest", "haystack needle test")
 

--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -1,12 +1,13 @@
 # from functools import cached_property
-from logzero import logger
 from broker.exceptions import NotImplementedError, HostError
 from broker.session import ContainerSession, Session
 from broker.settings import settings
+from broker.logger import init_logger
 
+logger = init_logger(__name__)
+logger.propagate = True
 
 class Host:
-
     default_timeout = 0  # timeout in ms, 0 is infinite
 
     def __init__(self, hostname=None, name=None, from_dict=False, **kwargs):

--- a/broker/session.py
+++ b/broker/session.py
@@ -2,10 +2,13 @@ import os
 import socket
 import tempfile
 from pathlib import Path
-from logzero import logger
+from logging import getLogger
 from ssh2.session import Session as ssh2_Session
 from ssh2 import sftp as ssh2_sftp
 from broker import helpers
+
+logger = getLogger(__name__)
+logger.propagate = True
 
 SESSIONS = {}
 


### PR DESCRIPTION
Replaces deprecated `logzero` by a ntaive `logging` lib
inroduces logger hierarchy per module (handler, formatter inheritance, ...)

This complements the changes introduced in robottelo by https://github.com/SatelliteQE/robottelo/pull/11332

TBD:
- [ ] figure out initialization when broker is run from CLI (`__main__`)
- [ ]  figure out a way of adding broker's external lib loggers (`awxkit`,...) to the hierarchy