### PR TITLE
Custom socket connect timeout in Session()

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -68,6 +68,7 @@ class Host:
             password=password,
             port=_port,
             key_filename=key_filename,
+            timeout=timeout
         )
 
     def close(self):

--- a/broker/session.py
+++ b/broker/session.py
@@ -31,7 +31,8 @@ class Session:
         sock.settimeout(kwargs.get("timeout"))
         port = kwargs.get("port", 22)
         key_filename = kwargs.get("key_filename")
-        helpers.simple_retry(sock.connect, [(host, port)])
+        timeout = kwargs.get("timeout", 60)
+        helpers.simple_retry(sock.connect, [(host, port)], max_timeout=timeout)
         self.session = ssh2_Session()
         self.session.handshake(sock)
         if key_filename:

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -70,7 +70,7 @@ if not settings_path.exists():
 validators = [
     Validator("HOST_USERNAME", default="root"),
     Validator("HOST_PASSWORD", default="toor"),
-    Validator("HOST_CONNECTION_TIMEOUT", default=None),
+    Validator("HOST_CONNECTION_TIMEOUT", default=60),
     Validator("HOST_SSH_PORT", default=22),
     Validator("HOST_SSH_KEY_FILENAME", default=None),
     Validator("LOGGING", is_type_of=dict),


### PR DESCRIPTION
What?
Let the user give a timeout for socket.connect(). Default is still 60.

Why? 
In cloud VMs, we get Connection Refused as the machine is not ready to take ssh connection just yet. Increasing the timeouts(reties) solves the issue.

Usage:
```
with Session(username="ec2-user",  hostname=hostname,  key_filename=private_key_path, socket_connect_timeout=500) as host:
      assert "hostname" in host.run("rpm -q hostname").stdout
```