### PR TITLE
Add a tail_file context manager to the Host class

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -1,4 +1,3 @@
-# from functools import cached_property
 from logzero import logger
 from broker.exceptions import NotImplementedError, HostError
 from broker.session import ContainerSession, Session
@@ -6,7 +5,6 @@ from broker.settings import settings
 
 
 class Host:
-
     default_timeout = 0  # timeout in ms, 0 is infinite
 
     def __init__(self, hostname=None, name=None, from_dict=False, **kwargs):

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -89,6 +89,13 @@ def test_container_e2e():
                 loc_settings_path.read_bytes() == data
             ), "Local file is different from the received one (return_data=True)"
             assert data == Path(tmp.file.name).read_bytes(), "Received files do not match"
+        # test the tail_file context manager
+        tailed_file = f"{remote_dir}/tail_me.txt"
+        c_host.execute(f"echo 'hello world' > {tailed_file}")
+        with c_host.session.tail_file(tailed_file) as tf:
+            c_host.execute(f"echo 'this is a new line' >> {tailed_file}")
+        assert 'this is a new line' in tf.stdout
+        assert 'hello world' not in tf.stdout
 
 
 def test_container_e2e_mp():

--- a/tests/functional/test_satlab.py
+++ b/tests/functional/test_satlab.py
@@ -86,6 +86,13 @@ def test_tower_host():
                 loc_settings_path.read_bytes() == data
             ), "Local file is different from the received one (return_data=True)"
             assert data == Path(tmp.file.name).read_bytes(), "Received files do not match"
+        # test the tail_file context manager
+        tailed_file = f"{remote_dir}/tail_me.txt"
+        r_host.execute(f"echo 'hello world' > {tailed_file}")
+        with r_host.session.tail_file(tailed_file) as tf:
+            r_host.execute(f"echo 'this is a new line' >> {tailed_file}")
+        assert 'this is a new line' in tf.stdout
+        assert 'hello world' not in tf.stdout
 
 
 def test_tower_host_mp():


### PR DESCRIPTION
This is a pretty common request and should be useful in a number of scenarios. Usage is pretty simple:
```python
    with my_host.session.tail_file("/var/log/messages") as res:
        # do something that creates new messages
    print(res.stdout)
```