### PR TITLE
Quick fix for AnsibleTower provider

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -180,9 +180,8 @@ class AnsibleTower(Provider):
         if prov_inv:
             logger.debug(f"prov_inv: {prov_inv}")
             broker_args["inventory"] = prov_inv
-        caller_host._prov_inst.release(
-            broker_args.get("source_vm", caller_host.name), broker_args
-        )
+        source_vm = broker_args.pop("source_vm", caller_host.name)
+        caller_host._prov_inst.release(source_vm, broker_args)
 
     def _set_attributes(self, host_inst, broker_args=None, misc_attrs=None):
         host_inst.__dict__.update(

--- a/tests/data/ansible_tower/fake_workflows.json
+++ b/tests/data/ansible_tower/fake_workflows.json
@@ -4,5 +4,11 @@
     "type": "workflow_job_template",
     "url": "/api/v2/workflow_job_templates/34/",
     "name": "deploy-base-rhel"
+  },
+  {
+    "id": 35,
+    "type": "workflow_job_template",
+    "url": "/api/v2/workflow_job_templates/35/",
+    "name": "remove-vm"
   }
 ]


### PR DESCRIPTION
This change ensures that we don't send multiple "source_vm" parameters into the AnsibleTower release method.