### PR TITLE
Allow remote_copy to copy to a different path

### DIFF
--- a/broker/logger.py
+++ b/broker/logger.py
@@ -138,7 +138,8 @@ def setup_logzero(
     path="logs/broker.log",
 ):
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    patch_awx_for_verbosity(awxkit.api)
+    if isinstance(level, str) and level.lower() == "trace":
+        patch_awx_for_verbosity(awxkit.api)
     set_log_level(level)
     set_file_logging(file_level, path)
     if formatter:

--- a/broker/session.py
+++ b/broker/session.py
@@ -131,16 +131,17 @@ class Session:
         with sftp.open(destination, FILE_FLAGS, SFTP_MODE) as remote:
             remote.write(data)
 
-    def remote_copy(self, source, dest_host, ensure_dir=True):
+    def remote_copy(self, source, dest_host, dest_path=None, ensure_dir=True):
         """Copy a file from this host to another"""
+        dest_path = dest_path or source
         sftp_down = self.session.sftp_init()
         sftp_up = dest_host.session.session.sftp_init()
         if ensure_dir:
-            dest_host.run(f"mkdir -p {Path(source).absolute().parent}")
+            dest_host.session.run(f"mkdir -p {Path(dest_path).absolute().parent}")
         with sftp_down.open(
             source, ssh2_sftp.LIBSSH2_FXF_READ, ssh2_sftp.LIBSSH2_SFTP_S_IRUSR
         ) as download:
-            with sftp_up.open(source, FILE_FLAGS, SFTP_MODE) as upload:
+            with sftp_up.open(dest_path, FILE_FLAGS, SFTP_MODE) as upload:
                 for size, data in download:
                     upload.write(data)
 

--- a/tests/functional/test_satlab.py
+++ b/tests/functional/test_satlab.py
@@ -117,3 +117,12 @@ def test_tower_host_mp():
                     loc_settings_path.read_bytes() == data
                 ), "Local file is different from the received one (return_data=True)"
                 assert data == Path(tmp.file.name).read_bytes(), "Received files do not match"
+        # test remote copy from one host to another
+        r_hosts[0].session.remote_copy(
+            source=f"{remote_dir}/{loc_settings_path.name}",
+            dest_host=r_hosts[1],
+            dest_path=f"/root/{loc_settings_path.name}"
+        )
+        res = r_hosts[1].execute(f"ls /root")
+        assert loc_settings_path.name in res.stdout
+


### PR DESCRIPTION
This change allows a user to supply a different destination path for remote_copy.

Fixes #165