### PR TITLE
Update build action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,9 +23,8 @@ jobs:
 
     - name: Setup and Build
       run: |
-        pip install -U pip
-        pip install .[setup]
-        python setup.py sdist bdist_wheel
+        pip install -U pip build
+        python -m build
         python -m twine check dist/*
 
     - name: Build and publish


### PR DESCRIPTION
The new process has been simplified now that we've moved away from using setup.py and rely on pyproject.toml
This uses the newer build system recommended by PyPA