### PR TITLE
Add packaging to list of dependencies

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -156,14 +156,13 @@ def populate_providers(click_group):
 def cli(version):
     """Command-line interface for interacting with providers."""
     if version:
+        from packaging.version import Version
         import pkg_resources
+        import requests
 
         broker_version = pkg_resources.get_distribution("broker").version
         # check the latest version publish to PyPi
         try:
-            from packaging.version import Version
-            import requests
-
             latest_version = Version(
                 requests.get("https://pypi.org/pypi/broker/json", timeout=60).json()["info"][
                     "version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "click",
     "dynaconf<4.0.0",
     "logzero",
+    "packaging",
     "pyyaml",
     "setuptools",
     "ssh2-python",


### PR DESCRIPTION
Now that packaging is no longer part of the standard library, we need to add it to the list of dependencies. This solves the issue seen when trying to run `broker --help`.