### PR TITLE
Swap Broker formatting from black to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,9 @@
 # configuration for pre-commit git hooks
 repos:
-- repo: https://github.com/psf/black
-  rev: 23.3.0
-  hooks:
-  -   id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.277
+  rev: v0.1.6
   hooks:
-    - id: ruff
+    - id: ruff  # Linter
       args: [--fix, --exit-non-zero-on-fix]
+    - id: ruff-format  # Formatter

--- a/broker/broker.py
+++ b/broker/broker.py
@@ -186,7 +186,7 @@ class Broker:
         self._kwargs.update(kwargs)
         if not self._provider_actions:
             raise self.BrokerError("Could not determine an appropriate provider")
-        for action, _arg in self._provider_actions.items():
+        for action in self._provider_actions:
             provider, method = PROVIDER_ACTIONS[action]
         logger.info(f"Using provider {provider.__name__} for execution")
         return self._act(provider, method)

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -164,7 +164,7 @@ class Container(Provider):
                     if "/" in p:
                         p, s = p.split("/")
                     else:
-                        p, s = p, "tcp"
+                        s = "tcp"
                     mapping[f"{p}/{s}"] = int(h) if h else None
         elif settings.container.auto_map_ports:
             mapping = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,21 +70,8 @@ include = ["broker"]
 testpaths = ["tests"]
 addopts = ["-v", "-l", "--color=yes", "--code-highlight=yes"]
 
-[tool.black]
-line-length = 100
-target-version = ["py310", "py311"]
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.venv
-  | build
-  | dist
-  | tests/data
-)/
-'''
-
 [tool.ruff]
+line-length = 100
 exclude = ["tests/"]
 target-version = "py311"
 fixable = ["ALL"]


### PR DESCRIPTION
Ruff now offers code formatting that is largely black-compatible, with some deviations [1]. Since we are already using Ruff for code linting in the project, we can also rely on it to handle code formatting. This will not only decrease the number of dependencies, but also be faster and (arguably) better formatted.

[1] - https://docs.astral.sh/ruff/formatter/black/