### PR TITLE
Fix variable name in example broker_settings

### DIFF
--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -58,7 +58,7 @@ TestProvider:
 nicks:
     rhel7:
         workflow: "deploy-base-rhel"
-        rhel_version: "7.9"
+        deploy_rhel_version: "7.9"
         notes: "Requested by broker"
     test_nick:
         test_action: "fake"


### PR DESCRIPTION
This PR just changes a variable name in the example `nicks` section of `broker_settings.yaml.example`.  No code change.
