### PR TITLE
Add IPv6 support

### DIFF
--- a/broker/settings.py
+++ b/broker/settings.py
@@ -92,6 +92,8 @@ validators = [
     Validator("HOST_CONNECTION_TIMEOUT", default=60),
     Validator("HOST_SSH_PORT", default=22),
     Validator("HOST_SSH_KEY_FILENAME", default=None),
+    Validator("HOST_IPV6", default=False),
+    Validator("HOST_IPV4_FALLBACK", default=True),
     Validator("LOGGING", is_type_of=dict),
     Validator(
         "LOGGING.CONSOLE_LEVEL",

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -9,6 +9,10 @@ host_username: root
 host_password: "<password>"
 host_ssh_port: 22
 host_ssh_key_filename: "</path/to/the/ssh-key>"
+# Default all host ssh connections to IPv6
+host_ipv6: False
+# If IPv6 connection attempts fail, fallback to IPv4
+host_ipv4_fallback: True
 # Provider settings
 AnsibleTower:
     base_url: "https://<ansible tower host>/"


### PR DESCRIPTION
This change is mostly focused around the addition of IPv6 connection functionality to Broker's Host Sessions.
Included are options for an ipv6 connection preference with an opt-out ipv6 connection fallback.
These have also been added to the settings file.