### PR TITLE
AnsibleTower inventory updates/fixes

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -175,6 +175,10 @@ class Host:
             "tower_inventory",
             "job_id",
             "_attrs",
+            "ip",
+            "os_distribution",
+            "os_distribution_version",
+            "reported_devices",
         )
         ret_dict = {
             "name": getattr(self, "name", None),

--- a/tests/data/ansible_tower/fake_workflows.json
+++ b/tests/data/ansible_tower/fake_workflows.json
@@ -3,12 +3,14 @@
     "id": 34,
     "type": "workflow_job_template",
     "url": "/api/v2/workflow_job_templates/34/",
-    "name": "deploy-base-rhel"
+    "name": "deploy-base-rhel",
+    "extra_vars": "{\"deploy_scenario\": \"baserhel\", \"deploy_rhel_version\": \"\", \"host_type\": \"host\", \"deploy_flavor\": \"prod-ssd.memory.xs\"}"
   },
   {
     "id": 35,
     "type": "workflow_job_template",
     "url": "/api/v2/workflow_job_templates/35/",
-    "name": "remove-vm"
+    "name": "remove-vm",
+    "extra_vars": "{\"source_vm\": \"\", \"host_type\": \"host\"}"
   }
 ]


### PR DESCRIPTION
- In `_merge_artifacts`, update documented values for `strategy` param and add some code comments documenting behavior.
- Rename `job_attrs` to `artifacts` in `construct_host`, to reflect the source of the data.
- In `execute`, send a new variable, `_broker_extra_vars`, containing a copy of any key/value pairs sent as `extra_vars` that aren't defined on the workflow. This will be used to track any custom variables defined by broker.
- Store and display host-specific inventory details (ip address, nics, etc.) at the top-level, outside of `_broker_args`:

```
[INFO 240208 09:55:00] 1: host.example.com:
    _broker_args:
      _broker_origin: broker_cli:tpapaioa
[...]
      tpapaioa_arg1: val1
      workflow: deploy-rhel
    _broker_provider: AnsibleTower
    _broker_provider_instance: aap
    hostname: host.example.com
    ip: 192.168.0.10
    name: tpapaioa-rhel-7.9-abcdef
    os_distribution: RedHat
    os_distribution_version: '7.9'
    reported_devices:
      nics:
      - lo
      - eth0
    tower_inventory: inventory-name
    type: host
```
