### PR TITLE
Split ssh2-python into an extra dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Install Broker either by cloning locally with `pip install .` or with `pip insta
 
 Copy the example settings file to `broker_settings.yaml` and edit it.
 
+(optional) If you are using Broker for ssh-based host interaction, install one of the supported ssh backends.
+```
+# For python 3.12+
+pip install broker[ssh2]
+
+# For python 3.11 and below
+pip install broker[ssh2_py311]
+```
+
 (optional) If you are using the Container provider, install the extra dependency based on your container runtime of choice with either `pip install broker[podman]` or `pip install broker[docker]`.
 
 (optional) If you are using the Beaker provider, install the extra dependency with `dnf install krb5-devel` and then `pip install broker[beaker]`.

--- a/broker/session.py
+++ b/broker/session.py
@@ -14,20 +14,25 @@ import socket
 import tempfile
 
 from logzero import logger
-from ssh2 import sftp as ssh2_sftp
-from ssh2.session import Session as ssh2_Session
 
 from broker import exceptions, helpers
 
-SESSIONS = {}
+try:
+    from ssh2 import sftp as ssh2_sftp
+    from ssh2.session import Session as ssh2_Session
 
-SFTP_MODE = (
-    ssh2_sftp.LIBSSH2_SFTP_S_IRUSR
-    | ssh2_sftp.LIBSSH2_SFTP_S_IWUSR
-    | ssh2_sftp.LIBSSH2_SFTP_S_IRGRP
-    | ssh2_sftp.LIBSSH2_SFTP_S_IROTH
-)
-FILE_FLAGS = ssh2_sftp.LIBSSH2_FXF_CREAT | ssh2_sftp.LIBSSH2_FXF_WRITE
+    SFTP_MODE = (
+        ssh2_sftp.LIBSSH2_SFTP_S_IRUSR
+        | ssh2_sftp.LIBSSH2_SFTP_S_IWUSR
+        | ssh2_sftp.LIBSSH2_SFTP_S_IRGRP
+        | ssh2_sftp.LIBSSH2_SFTP_S_IROTH
+    )
+    FILE_FLAGS = ssh2_sftp.LIBSSH2_FXF_CREAT | ssh2_sftp.LIBSSH2_FXF_WRITE
+except ImportError:
+    logger.warning(
+        "ssh2-python is not installed, ssh actions will not work.\n"
+        "To use ssh, run pip install broker[ssh2]."
+    )
 
 
 def _create_connect_socket(host, port, timeout, ipv6=False, ipv4_fallback=True, sock=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "packaging",
     "pyyaml",
     "setuptools",
-    "ssh2-python@git+https://github.com/jacobcallahan/ssh2-python.git"
 ]
 dynamic = ["version"]  # dynamic fields to update on build - version via setuptools_scm
 
@@ -38,6 +37,7 @@ dynamic = ["version"]  # dynamic fields to update on build - version via setupto
 Repository = "https://github.com/SatelliteQE/broker"
 
 [project.optional-dependencies]
+beaker = ["beaker-client"]
 dev = [
     "pre-commit",
     "pytest",
@@ -48,11 +48,12 @@ docker = [
     "paramiko"
 ]
 podman = ["podman-py"]
-beaker = ["beaker-client"]
 setup = [
     "build",
     "twine",
 ]
+ssh2 = ["ssh2-python@git+https://github.com/jacobcallahan/ssh2-python.git"]
+ssh2_py311 = ["ssh2-python"]
 
 [project.scripts]
 broker = "broker.commands:cli"


### PR DESCRIPTION
The intent of this change is to get us back to publishing Broker to PyPi. In order to do this, I split the ssh2-python github dependency from the main dependencies and into the the extras. As part of this, this also allows users to choose their ssh2-python backend (3.12 fork or 3.11 and earlier main package).