### PR TITLE
Moving ssh2-python fork dependency back to main list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "packaging",
     "pyyaml",
     "setuptools",
+    "ssh2-python@git+https://github.com/jacobcallahan/ssh2-python.git",
 ]
 dynamic = ["version"]  # dynamic fields to update on build - version via setuptools_scm
 


### PR DESCRIPTION
Since making it an extra didn't help with PyPi, I'm moving this back up until we have a better option. This will simplify installs from github.