### PR TITLE
truncate existing files on sftp write

### DIFF
--- a/broker/session.py
+++ b/broker/session.py
@@ -27,7 +27,9 @@ try:
         | ssh2_sftp.LIBSSH2_SFTP_S_IRGRP
         | ssh2_sftp.LIBSSH2_SFTP_S_IROTH
     )
-    FILE_FLAGS = ssh2_sftp.LIBSSH2_FXF_CREAT | ssh2_sftp.LIBSSH2_FXF_WRITE
+    FILE_FLAGS = (
+        ssh2_sftp.LIBSSH2_FXF_CREAT | ssh2_sftp.LIBSSH2_FXF_WRITE | ssh2_sftp.LIBSSH2_FXF_TRUNC
+    )
 except ImportError:
     logger.warning(
         "ssh2-python is not installed, ssh actions will not work.\n"


### PR DESCRIPTION
In our use case we create a backup of a config file, modify the config file (adding characters), perform testing and restore the original config from backup. We use sftp to read and write the backup. However the restore (sftp_write) ends with damaged config file. Damaged file consists of original content and few characters remained from modified file.

Adding flag LIBSSH2_FXF_TRUNC should solve the problem by truncating existing files.
see: https://libssh2.org/libssh2_sftp_open_ex.html