### PR TITLE
Fix module name for ssh2-python312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "packaging",
     "pyyaml",
     "setuptools",
-    "ssh2-python@git+https://github.com/jacobcallahan/ssh2-python.git",
+    "ssh2-python312@git+https://github.com/jacobcallahan/ssh2-python.git",
 ]
 dynamic = ["version"]  # dynamic fields to update on build - version via setuptools_scm
 


### PR DESCRIPTION
Ssh2-python dependency installation during broker installation is failing :
```
WARNING: Generating metadata for package ssh2-python produced metadata for project name ssh2-python312. Fix your #egg=ssh2-python fragments.
11:04:43  ERROR: Could not find a version that satisfies the requirement ssh2-python (unavailable) (from broker) (from versions: 0.1b1, 0.2.0, 0.2.1, 0.3.0, 0.3.1.post2, 0.3.1.post3, 0.4.0, 0.5.0, 0.5.0.post1, 0.5.1, 0.5.2, 0.5.3rc1, 0.5.3, 0.5.4, 0.5.5, 0.6.0, 0.7.0.post2, 0.7.0.post3, 0.7.0.post4, 0.7.0.post5, 0.8.0, 0.9.0, 0.9.1, 0.10.0, 0.11.0.post1, 0.13.0.post2, 0.14.0, 0.15.0, 0.15.0.post2, 0.15.0.post4, 0.15.0.post7, 0.15.0.post8, 0.15.0.post9, 0.16.0, 0.17.0, 0.18.0.post1, 0.19.0, 0.21.0, 0.22.0, 0.23.0, 0.24.0, 0.25.0, 0.26.0, 0.27.0, 1.0.0rc2, 1.0.0)
11:04:43  ERROR: No matching distribution found for ssh2-python (unavailable)
```