### PR TITLE
Add optional provider label support

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -191,7 +191,7 @@ def cli(version):
 @click.option("-c", "--count", type=int, help="Number of times broker repeats the checkout")
 @click.option(
     "-l",
-    "--labels",
+    "--provider-labels",
     type=str,
     help="A string representing the list"
     " of k=v pairs (comma-separated) to be used as provider resource"
@@ -204,7 +204,7 @@ def cli(version):
 )
 @provider_options
 @click.pass_context
-def checkout(ctx, background, nick, count, args_file, labels, **kwargs):
+def checkout(ctx, background, nick, count, args_file, provider_labels, **kwargs):
     """Checkout or "create" a Virtual Machine broker instance.
 
     COMMAND: broker checkout --workflow "workflow-name" --workflow_arg1 something
@@ -218,10 +218,10 @@ def checkout(ctx, background, nick, count, args_file, labels, **kwargs):
         broker_args["_count"] = count
     if args_file:
         broker_args["args_file"] = args_file
-    if labels:
-        broker_args["labels"] = {
-            f"broker.{label[0]}": "=".join(label[1:])
-            for label in [kv_pair.split("=") for kv_pair in labels.split(",")]
+    if provider_labels:
+        broker_args["provider_labels"] = {
+            label[0]: "=".join(label[1:])
+            for label in [kv_pair.split("=") for kv_pair in provider_labels.split(",")]
         }
 
     # if additional arguments were passed, include them in the broker args

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -190,8 +190,13 @@ def cli(version):
 @click.option("-n", "--nick", type=str, help="Use a nickname defined in your settings")
 @click.option("-c", "--count", type=int, help="Number of times broker repeats the checkout")
 @click.option(
-    "--labels", type=str, help="List of strings (comma-separated) to be used as AAP labels"
-)  # fixme - this should be provider-agnostic
+    "-l",
+    "--labels",
+    type=str,
+    help="A string representing the list"
+    " of k=v pairs (comma-separated) to be used as provider resource"
+    " labels (e.g. '-l k1=v1,k2=v2,k3=v3=z4').",
+)
 @click.option(
     "--args-file",
     type=click.Path(exists=True),

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -190,13 +190,16 @@ def cli(version):
 @click.option("-n", "--nick", type=str, help="Use a nickname defined in your settings")
 @click.option("-c", "--count", type=int, help="Number of times broker repeats the checkout")
 @click.option(
+    "--labels", type=str, help="List of strings (comma-separated) to be used as AAP labels"
+)  # fixme - this should be provider-agnostic
+@click.option(
     "--args-file",
     type=click.Path(exists=True),
     help="A json or yaml file mapping arguments to values",
 )
 @provider_options
 @click.pass_context
-def checkout(ctx, background, nick, count, args_file, **kwargs):
+def checkout(ctx, background, nick, count, args_file, labels, **kwargs):
     """Checkout or "create" a Virtual Machine broker instance.
 
     COMMAND: broker checkout --workflow "workflow-name" --workflow_arg1 something
@@ -210,6 +213,8 @@ def checkout(ctx, background, nick, count, args_file, **kwargs):
         broker_args["_count"] = count
     if args_file:
         broker_args["args_file"] = args_file
+    if labels:
+        broker_args["labels"] = labels.split(",")
     # if additional arguments were passed, include them in the broker args
     # strip leading -- characters
     broker_args.update(

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -219,7 +219,11 @@ def checkout(ctx, background, nick, count, args_file, labels, **kwargs):
     if args_file:
         broker_args["args_file"] = args_file
     if labels:
-        broker_args["labels"] = labels.split(",")
+        broker_args["labels"] = {
+            f"broker.{label[0]}": "=".join(label[1:])
+            for label in [kv_pair.split("=") for kv_pair in labels.split(",")]
+        }
+
     # if additional arguments were passed, include them in the broker args
     # strip leading -- characters
     broker_args.update(

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -653,7 +653,7 @@ class AnsibleTower(Provider):
             compiled_host_info = [self._compile_host_info(host) for host in hosts_bar]
         return compiled_host_info
 
-    def extend(self, target_vm, new_expire_time=None):
+    def extend(self, target_vm, new_expire_time=None, provider_labels=None):
         """Run the extend workflow with defaults args.
 
         :param target_vm: This should be a host object
@@ -668,6 +668,7 @@ class AnsibleTower(Provider):
             workflow=settings.ANSIBLETOWER.extend_workflow,
             target_vm=target_vm.name,
             new_expire_time=new_expire_time or settings.ANSIBLETOWER.get("new_expire_time"),
+            provider_labels=provider_labels,
         )
 
     def provider_help(

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -590,7 +590,7 @@ class AnsibleTower(Provider):
         if inventory := kwargs.pop("inventory", None):
             payload["inventory"] = inventory
             logger.info(f"Using tower inventory: {self._translate_inventory(inventory)}")
-        if labels := kwargs.pop("labels", None):
+        if labels := kwargs.pop("provider_labels", None):
             payload["labels"] = self._resolve_labels(labels, target)
             # record labels also as extra vars - use key=value format
             kwargs.update(

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -594,8 +594,9 @@ class AnsibleTower(Provider):
         if labels := kwargs.pop("provider_labels", None):
             payload["labels"] = self._resolve_labels(labels, target)
             # record labels also as extra vars - use key=value format
-            kwargs.update(
-                {f"_broker_label_{label[0]}": "=".join(label[1:]) for label in labels.items()}
+            kwargs["provider_labels"] = kwargs.get("provider_labels", {})
+            kwargs["provider_labels"].update(
+                {label[0]: "=".join(label[1:]) for label in labels.items()}
             )
         elif self.inventory:
             payload["inventory"] = self.inventory

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -592,7 +592,13 @@ class AnsibleTower(Provider):
             logger.info(f"Using tower inventory: {self._translate_inventory(inventory)}")
         if labels := kwargs.pop("labels", None):
             payload["labels"] = self._resolve_labels(labels, target)
-            kwargs["_labels"] = ",".join(labels)
+            # record labels also as extra vars - use key=value format
+            kwargs.update(
+                {
+                    f"_broker_label_{label[0]}": "=".join(label[1:])
+                    for label in [kv_pair.split("=") for kv_pair in labels]
+                }
+            )
         elif self.inventory:
             payload["inventory"] = self.inventory
             logger.info(f"Using tower inventory: {self._translate_inventory(self.inventory)}")

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -277,7 +277,7 @@ class Container(Provider):
         # prefix eventual label keys with 'broker.' to conform to the docker guidelines
         # https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations
         kwargs["provider_labels"] = {
-            f"broker.{label[0]}": label[1] for label in kwargs["provider_labels"].items()
+            f"broker.{label[0]}": label[1] for label in kwargs.get("provider_labels", {}).items()
         }
         # process eventual labels that were passed externally, split by "="
         kwargs["provider_labels"].update(

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -274,6 +274,11 @@ class Container(Provider):
         if origin[1]:
             envars["JENKINS_URL"] = origin[1]
         kwargs["environment"] = envars
+
+        # process eventual provider labels for each setting level
+        kwargs["provider_labels"] = kwargs.get("provider_labels", {})
+        kwargs["provider_labels"].update(settings.get("provider_labels", {}))
+        kwargs["provider_labels"].update(settings.CONTAINER.get("provider_labels", {}))
         # prefix eventual label keys with 'broker.' to conform to the docker guidelines
         # https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations
         kwargs["provider_labels"] = {

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -274,7 +274,13 @@ class Container(Provider):
         if origin[1]:
             envars["JENKINS_URL"] = origin[1]
         kwargs["environment"] = envars
-        kwargs["labels"] = envars
+        # process eventual labels that were passed externally, split by "="
+        kwargs["labels"] = {
+            f"broker.{label[0]}": "=".join(label[1:])
+            for label in [kv_pair.split("=") for kv_pair in kwargs.get("labels", {})]
+        }
+        # append origin as labels too
+        kwargs["labels"].update({"broker.origin": origin[0], "broker.jenkins.url": origin[1]})
         container_inst = self.runtime.create_container(container_host, **kwargs)
         container_inst.start()
         return container_inst

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -274,8 +274,17 @@ class Container(Provider):
         if origin[1]:
             envars["JENKINS_URL"] = origin[1]
         kwargs["environment"] = envars
+        # prefix eventual label keys with 'broker.' to conform to the docker guidelines
+        # https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations
+        kwargs["provider_labels"] = {
+            f"broker.{label[0]}": label[1] for label in kwargs["provider_labels"].items()
+        }
         # process eventual labels that were passed externally, split by "="
-        kwargs["labels"].update({"broker.origin": origin[0], "broker.jenkins.url": origin[1]})
+        kwargs["provider_labels"].update(
+            {"broker.origin": origin[0], "broker.jenkins.url": origin[1]}
+        )
+        # rename the dict key to the name of the arg recognized by provider
+        kwargs["labels"] = kwargs.pop("provider_labels")
         container_inst = self.runtime.create_container(container_host, **kwargs)
         container_inst.start()
         return container_inst

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -275,11 +275,6 @@ class Container(Provider):
             envars["JENKINS_URL"] = origin[1]
         kwargs["environment"] = envars
         # process eventual labels that were passed externally, split by "="
-        kwargs["labels"] = {
-            f"broker.{label[0]}": "=".join(label[1:])
-            for label in [kv_pair.split("=") for kv_pair in kwargs.get("labels", {})]
-        }
-        # append origin as labels too
         kwargs["labels"].update({"broker.origin": origin[0], "broker.jenkins.url": origin[1]})
         container_inst = self.runtime.create_container(container_host, **kwargs)
         container_inst.start()

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -67,7 +67,7 @@ def test_containerhost_query():
 
 
 def test_container_e2e():
-    with Broker(container_host="ubi8:latest") as c_host:
+    with Broker(container_host="ubi8:latest", provider_labels={"l1": "v1", "l2": None}) as c_host:
         assert c_host._cont_inst.top()["Processes"]
         res = c_host.execute("hostname")
         assert res.stdout.strip() == c_host.hostname
@@ -87,6 +87,9 @@ def test_container_e2e():
                 SETTINGS_PATH.read_bytes() == data
             ), "Local file is different from the received one (return_data=True)"
             assert data == Path(tmp.file.name).read_bytes(), "Received files do not match"
+        # assert labels
+        assert c_host._cont_inst.labels.get("broker.l1") == "v1"
+        assert c_host._cont_inst.labels.get("broker.l2") == ""
         # test the tail_file context manager
         tailed_file = f"{remote_dir}/tail_me.txt"
         c_host.execute(f"echo 'hello world' > {tailed_file}")

--- a/tests/functional/test_satlab.py
+++ b/tests/functional/test_satlab.py
@@ -124,3 +124,17 @@ def test_tower_host_mp():
         )
         res = r_hosts[1].execute(f"ls /root")
         assert SETTINGS_PATH.name in res.stdout
+
+
+def test_tower_provider_labels():
+    """Assert labels being created on AAP and OSP metadata 
+    being attached accordingly
+    """
+    with Broker(workflow="deploy-rhel", provider_labels={"l1": "v1", "l2": ""}) as r_host:
+        # check provider labels in the resulting host object
+        assert r_host.provider_labels.get("l1") == "v1"
+        assert r_host.provider_labels.get("l2") == ""
+        # assert the AAP labels got created on the provider
+        aap_labels = [l.name for l in r_host._prov_inst.v2.labels.get().results]
+        assert "l1=v1" in aap_labels
+        assert "l2" in aap_labels


### PR DESCRIPTION
Extend broker's AnsibleTower and Container provider functionality to pass labels to be set to the spawned resources.
It accepts a string of comma-separated label values.
Broker then uses awxkit session to resolve their id's (required for the job `/launch` payload) and eventually creates the non-existing labels.

User is required to have granted permissions for creating new labels (if that's even a thing) on AAP.

Plan is to implement the labeling functionality to all providers that have support of labels, e.g.
https://docs.docker.com/config/labels-custom-metadata/

example usage:
```
# ansible tower provider
$ broker execute deploy-rhel --provider-labels foo=bar,baz
```
translates to:
![Selection_674](https://github.com/SatelliteQE/broker/assets/11773362/cfeb3c17-8c88-4752-b616-f4acebfb4314)
(AAP labels are single string items)

```
# container provider with additional labels configured in the nick:

nick:

  rhel8_docker:
    container_host: "ubi8:latest"
    environment:
      BUILD_URL: "https://intergalactic.planetary/planetary/intergalactic"
    provider_labels:
      nick_label_1: myval1
      nick_label_2: myval2


$ broker checkout --nick rhel8_docker --provider-labls cli1=val1,nick_label_2=overriden_by_cli_param
[INFO 240418 14:13:37] Using provider Container to checkout
[INFO 240418 14:13:45] Host: 97c993636de8
```
translates to:
```
$ docker inspect 97c993636de8
...
            "Labels": {
                "architecture": "x86_64",
                "broker.jenkins.url": "",
                "broker.nick_label_1": "myval1",
                "broker.nick_label_2": "myval2",
                "broker.origin": "broker_cli:rplevka",
               ...
...
```