### PR TITLE
Update functional test to deploy newer satellite version.

### DIFF
--- a/tests/data/cli_scenarios/satlab/checkout_sat_613.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_sat_613.yaml
@@ -1,2 +1,2 @@
 workflow: deploy-satellite
-deploy_sat_version: "6.11"
+deploy_sat_version: "6.13"


### PR DESCRIPTION
The functional test which deploy Satellite 6.11 failed in internal testing. Updating it to use Satellite 6.13, as 6.11 is now EOL.