### PR TITLE
Remove the duplicate subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ broker --output-file inventory.json inventory
 
 **Run Broker in the background**
 
-Certain Broker actions can be run in the background, these currently are: checkout, checkin, duplicate, and execute. When running a command in this mode, it will spin up a new Broker process and no longer log to stderr. To check progress, you can still follow broker's log file.
+Certain Broker actions can be run in the background, these currently are: checkout, checkin, and execute. When running a command in this mode, it will spin up a new Broker process and no longer log to stderr. To check progress, you can still follow broker's log file.
 Note that background mode will interfere with output options for execute since it won't be able to print to stdout. Those should kept in log mode.
 ```
 broker checkout --background --nick rhel7

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -306,38 +306,6 @@ def extend(vm, background, all_, sequential, filter, **kwargs):
     Broker(hosts=to_extend, **broker_args).extend(sequential=sequential)
 
 
-@loggedcli()
-@click.argument("vm", type=str, nargs=-1)
-@click.option("-b", "--background", is_flag=True, help="Run duplicate in the background")
-@click.option("-c", "--count", type=int, help="Number of times broker repeats the duplicate")
-@click.option("--all", "all_", is_flag=True, help="Select all VMs")
-@click.option("--filter", type=str, help="Duplicate only what matches the specified filter")
-def duplicate(vm, background, count, all_, filter):
-    """Duplicate a broker-procured vm.
-
-    DEPRECATED! This will be removed in Broker 0.5. If you need this feature, please open an issue.
-
-    COMMAND: broker duplicate <vm hostname>|<local id>|all
-    """
-    logger.warning(
-        "Duplicate will be remove in Broker 0.5. If you need this feature, please open an issue."
-    )
-    if background:
-        helpers.fork_broker()
-    inventory = helpers.load_inventory(filter=filter)
-    for num, host in enumerate(inventory):
-        if str(num) in vm or host["hostname"] in vm or host.get("name") in vm or all_:
-            broker_args = host.get("_broker_args")
-            if broker_args:
-                if count:
-                    broker_args["_count"] = count
-                logger.info(f"Duplicating: {host['hostname']}")
-                broker_inst = Broker(**broker_args)
-                broker_inst.checkout()
-            else:
-                logger.warning(f"Unable to duplicate {host['hostname']}, no _broker_args found")
-
-
 @loggedcli(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @click.option("-b", "--background", is_flag=True, help="Run execute in the background")
 @click.option("--nick", type=str, help="Use a nickname defined in your settings")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ docker = [
     "docker",
     "paramiko"
 ]
-podman = ["podman-py"]
+podman = ["podman"]
 setup = [
     "build",
     "twine",


### PR DESCRIPTION
This was previously deprecated and we received no feedback to keep it in.
I also updated the podman python binding to the newly active name.