### PR TITLE
Remove deprecated usage of pkg_resources in favor of importlib.metadata.

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -156,12 +156,14 @@ def populate_providers(click_group):
 def cli(version):
     """Command-line interface for interacting with providers."""
     if version:
+        from importlib.metadata import version
+
         from packaging.version import Version
-        import pkg_resources
         import requests
 
-        broker_version = pkg_resources.get_distribution("broker").version
-        # check the latest version publish to PyPi
+        broker_version = version("broker")
+
+        # Check against the latest version published to PyPi
         try:
             latest_version = Version(
                 requests.get("https://pypi.org/pypi/broker/json", timeout=60).json()["info"][


### PR DESCRIPTION
Removes the deprecated usage of the `pkg_resources` module.

https://github.com/SatelliteQE/broker/issues/283

This change affects only the internals of the `broker --version` command. The command output is unaffected. Example output with this change:

```
$ broker --version
Version: 0.4.10.dev2+g6db4e5b
Broker Directory: /home/tpapaioa/.broker
Settings File: /home/tpapaioa/.broker/broker_settings.yaml
Inventory File: /home/tpapaioa/.broker/inventory.yaml
Log File: /home/tpapaioa/.broker/logs/broker.log
```