### PR TITLE
Fix file logging level issue

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -393,7 +393,8 @@ def fork_broker():
     if pid:
         logger.info(f"Running broker in the background with pid: {pid}")
         sys.exit(0)
-    update_log_level(None, None, "silent")
+    b_log.set_log_level("silent")
+    b_log.set_file_logging("silent")
 
 
 def handle_keyboardinterrupt(*args):

--- a/broker/logger.py
+++ b/broker/logger.py
@@ -57,10 +57,8 @@ logzero.DEFAULT_COLORS[LOG_LEVEL.TRACE.value] = logzero.colors.Fore.MAGENTA
 
 
 def patch_awx_for_verbosity(api):
-    """Patch the awxkit API to log when we're at trace level."""
-    client = api.client
-    awx_log = client.log
-
+    """Patch the awxkit API to enable trace-level logging of API calls to Ansible provider."""
+    awx_log = api.client.log
     awx_log.parent = logzero.logger
 
     def patch(cls, name):
@@ -120,7 +118,7 @@ def set_file_logging(level=settings.logging.file_level, path="logs/broker.log"):
         # settings.logging.file_level. Otherwise, use the value from settings.
         old_log_level = resolve_log_level(settings.logging.file_level)
         new_log_level = resolve_log_level(level)
-        log_level = new_log_level if new_log_level.value < old_log_level.value else old_log_level
+        log_level = new_log_level if new_log_level < old_log_level else old_log_level
 
     path = BROKER_DIRECTORY.joinpath(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -143,10 +141,7 @@ def setup_logzero(
 ):
     """Call logzero setup with the given settings."""
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    # FIXME helpers.update_log_level also needs to do this,
-    # if "--log-level trace" is passed to the CLI.
-    if isinstance(level, str) and level.lower() == "trace":
-        patch_awx_for_verbosity(awxkit.api)
+    patch_awx_for_verbosity(awxkit.api)
     set_log_level(level)
     set_file_logging(file_level, path)
     if formatter:


### PR DESCRIPTION
Fixes #223

1. This PR fixes the issue, so that with the following log levels set in `~/.broker/broker_settings.yaml`:

```
logging:
  console_level: info
  file_level: trace
```

The CLI logs only `info`-level messages to the console, but logs `trace`-level messages to `broker.log`:

```
$ broker execute --workflow list-templates --artifacts last
[INFO 240417 11:02:34] Using provider AnsibleTower for execution
[INFO 240417 11:02:34] Using token authentication
[INFO 240417 11:02:35] No inventory specified, Ansible Tower will use a default.
[INFO 240417 11:02:36] Waiting for job: 
[...]

$ cat ~/.broker/logs/broker.log
[...]
[D 240417 11:02:34 __init__:75] Registered help option inventory for provider inventory
[T 240417 11:02:34 commands:26] Calling func=<function execute at 0x7f1785d48180>(*args=() **kwargs={'workflow': 'list-templates', 'artifacts': 'last', 'background': False, 'nick': None, 'output_format': 'log', 'args_file': None, 'job_tem
plate': None, 'tower_inventory': None}
[D 240417 11:02:34 broker:94] Broker instantiated with kwargs={'workflow': 'list-templates', 'artifacts': 'last'}
[I 240417 11:02:34 broker:191] Using provider AnsibleTower for execution
[...]
[T 240417 11:03:47 commands:28] Finished func=<function execute at 0x7f1785d48180>(*args=() **kwargs={'workflow': 'list-templates', 'artifacts': 'last', 'background': False, 'nick': None, 'output_format': 'log', 'args_file': None, 'job_template': None, 'tower_inventory': None}) retval=None
```

2. Also updated the logic so that the file level is never set higher than the console level, i.e., the log file will always log what is logged to the console, if not more.

Example behavior:

- Console level set to `info` and file level set to `debug`:
```
$ vim ~/.broker/broker_settings.yaml 
[...]
logging:
  console_level: info
  file_level: debug
[...]
```
The file level is lower than the console level, and this works as expected now, fixing issue #223 

- Console level set to `debug` and file level set to `info`:
```
logging:
  console_level: debug
  file_level: info
```
In this case, the file level is automatically adjusted to match the console level, which is lower. Info and debug messages are logged to both.


3. Also added a fix to `setup_logzero()`, so that it calls ` patch_awx_for_verbosity()` to patch the ansible api client and allow trace-level logging, no matter what the passed in value for `level` is. Before this fix, trace-level logging from the ansible client wasn't happening in the following cases:

- Trace logging is set for the log file but not for console:
```
console_level: info
file_level: trace
```

- Trace logging is enabled from the command line instead of from the settings file:
```
$ broker --log-level trace execute [...]
```