### PR TITLE
Docker: Handle container create kwargs properly

### DIFF
--- a/broker/binds/containers.py
+++ b/broker/binds/containers.py
@@ -179,6 +179,8 @@ class DockerBind(ContainerBind):
             self.uri = "ssh://{username}@{host}".format(**kwargs)
 
     def _sanitize_create_args(self, kwargs):
-        from docker.models.containers import RUN_CREATE_KWARGS
+        from docker.models.containers import RUN_CREATE_KWARGS, RUN_HOST_CONFIG_KWARGS
 
-        return {k: v for k, v in kwargs.items() if k in RUN_CREATE_KWARGS}
+        special_kwargs = ["ports", "volumes", "network", "networking_config"]
+        accepted_kwargs = RUN_HOST_CONFIG_KWARGS + RUN_CREATE_KWARGS + special_kwargs
+        return {k: v for k, v in kwargs.items() if k in accepted_kwargs}


### PR DESCRIPTION
This patch ensures that  all kwargs that are being passed to docker-py's container `create` method are sanitized properly and accepted. We missed `RUN_HOST_CONFIG_KWARGS` kwargs keys plus some extra kwargs that have a special handling in docker-py. See the snippet below.

https://github.com/docker/docker-py/blob/a3652028b1ead708bd9191efb286f909ba6c2a49/docker/models/containers.py#L1122-L1157