### PR TITLE
Broker changes for remote podman (tcp and ipv6)

### DIFF
--- a/broker/binds/containers.py
+++ b/broker/binds/containers.py
@@ -100,11 +100,12 @@ class ContainerBind:
     def create_container(self, image, command=None, **kwargs):
         """Create and return running container instance."""
         if net_name := settings.container.network:
-            if not self.get_network_by_attrs({"name": net_name}):
-                raise UserError(
-                    f"Network '{settings.container.network}' not found on container host."
-                )
-            kwargs["networks"] = {net_name: {"NetworkId": net_name}}
+            net_dict = {}
+            for name in net_name.split(","):
+                if not self.get_network_by_attrs({"name": name}):
+                    raise UserError(f"Network '{name}' not found on container host.")
+                net_dict[name] = {"NetworkId": name}
+            kwargs["networks"] = net_dict
         kwargs = self._sanitize_create_args(kwargs)
         return self.client.containers.create(image, command, **kwargs)
 

--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -58,7 +58,8 @@ class Container(Provider):
         Validator(
             "CONTAINER.host_password",
         ),
-        Validator("CONTAINER.host_port", default=22),
+        Validator("CONTAINER.host_port", default=2375),
+        Validator("CONTAINER.network", default=None),
         Validator("CONTAINER.timeout", default=360),
         Validator("CONTAINER.auto_map_ports", is_type_of=bool, default=True),
     ]
@@ -213,7 +214,7 @@ class Container(Provider):
         # add the container's port mapping to the host instance only if there are any ports open
         if cont_attrs.get("ports"):
             host_inst.exposed_ports = {
-                f"{k.split('/')[0]}": v[0]["HostPort"] for k, v in cont_attrs["ports"].items()
+                f"{k.split('/')[0]}": v[0]["HostPort"] for k, v in cont_attrs["ports"].items() if v
             }
         return host_inst
 

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -35,6 +35,7 @@ Container:
             host_password: "<plain text password>"
             host_port: None
             runtime: docker
+            network: null
             default: True
         - remote:
             host: "<remote hostname>"

--- a/tests/data/container/fake_networks.json
+++ b/tests/data/container/fake_networks.json
@@ -1,0 +1,59 @@
+[
+    {
+        "name": "podman1",
+        "id": "78a8f74414",
+        "driver": "bridge",
+        "network_interface": "cni-podman1",
+        "created": "2024-04-29T04:39:08.09789015-04:00",
+        "subnets": [
+            {
+                "subnet": "fd00::1:8:0/112",
+                "gateway": "fd00::1:8:1"
+            }
+        ],
+        "ipv6_enabled": true,
+        "internal": false,
+        "dns_enabled": true,
+        "ipam_options": {
+            "driver": "host-local"
+        }
+    },
+    {
+        "name": "podman2",
+        "id": "c785da3b9b",
+        "driver": "bridge",
+        "network_interface": "cni-podman2",
+        "created": "2024-04-29T04:32:25.30689015-04:00",
+        "subnets": [
+            {
+                "subnet": "10.89.0.0/24",
+                "gateway": "10.89.0.1"
+            }
+        ],
+        "ipv6_enabled": false,
+        "internal": false,
+        "dns_enabled": true,
+        "ipam_options": {
+            "driver": "host-local"
+        }
+    },
+    {
+        "name": "podman",
+        "id": "c0b7a1bb95",
+        "driver": "bridge",
+        "network_interface": "cni-podman0",
+        "created": "2024-07-26T15:05:00.256703131-04:00",
+        "subnets": [
+            {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+            }
+        ],
+        "ipv6_enabled": false,
+        "internal": false,
+        "dns_enabled": false,
+        "ipam_options": {
+            "driver": "host-local"
+        }
+    }
+]

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -38,6 +38,13 @@ def test_full_init():
     assert broker_inst._kwargs["test_action"] == "blank"
 
 
+def test_specified_instance():
+    """Make sure that a specified instance is used"""
+    broker_inst = Broker(nick="test_nick", TestProvider="test2")
+    host_checkout = broker_inst.checkout()
+    assert host_checkout._broker_provider_instance == "test2"
+
+
 def test_broker_e2e():
     """Run through the base functionality of broker"""
     broker_inst = Broker(nick="test_nick")


### PR DESCRIPTION
We have encountered a couple of issues that need to be solved in order to use Broker with remote podman hosts.

  First is an issue with the ssh-based connection to remote podman that was investigated in a previous issue. The
  solution to this from Broker's side is largely changing the connection string based on the host_port given.

  Second is to give Broker the ability to automatically find and pass along the correct network information when
  spinning up an ipv6 container. The solution for this is to list networks, search for one that is ipv6 enabled, then
  modify the container creation arguments to pass along that network information