### PR TITLE
Quick fix for docker ssh connection

### DIFF
--- a/broker/binds/containers.py
+++ b/broker/binds/containers.py
@@ -198,6 +198,8 @@ class DockerBind(ContainerBind):
         self._ClientClass = DockerClient
         if self.host == "localhost":
             self.uri = "unix://var/run/docker.sock"
+        elif kwargs.get("port") == SSH_PORT:
+            self.uri = "ssh://{username}@{host}:{port}".format(**kwargs)
         else:
             self.uri = "tcp://{username}@{host}".format(**kwargs)
 


### PR DESCRIPTION
This time correctly accounting for multiple connection options in the Docker bind, allowing ssh (which is what most people are currently using) to work.