### PR TITLE
Fix incomplete file downloads in ssh2 sftp_read

### DIFF
--- a/broker/binds/ssh2.py
+++ b/broker/binds/ssh2.py
@@ -182,7 +182,7 @@ class Session:
                 captured_data += data
             if return_data:
                 return captured_data
-            destination.write_bytes(data)
+            destination.write_bytes(captured_data)
 
     def sftp_write(self, source, destination=None, ensure_dir=True):
         """Sftp write a local file to a remote destination."""


### PR DESCRIPTION
This PR fixes a bug in the ssh2 / ssh2-python312 implementation of sftp_read, which was only saving the last chunk of file data locally, in cases where the sftp transfer involves multiple reads.