### PR TITLE
Add a curated output flag for inventory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "logzero",
     "packaging",
     "pyyaml",
+    "rich",
     "setuptools",
     "ssh2-python312",
 ]


### PR DESCRIPTION
This provides a styled middle ground between the default minimal view and the much more verbose detailed view.
This also give us an opportunity to explore different output styling with rich.

fixes #306