### PR TITLE
Introduction of broker config cli and much more!

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,11 +50,8 @@ jobs:
 
       - name: Unit Tests
         env:
-          BROKER_DIRECTORY: "${{ github.workspace }}/broker_dir"
           UV_SYSTEM_PYTHON: 1
         run: |
-          cp broker_settings.yaml.example ${BROKER_DIRECTORY}/broker_settings.yaml
-          uv pip install "broker[dev,docker] @ ."
-          ls -l "$BROKER_DIRECTORY"
+          uv pip install "broker[dev,podman] @ ."
           broker --version
           pytest -v tests/ --ignore tests/functional

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -208,8 +208,7 @@ def cli(version):
         table.add_row("Log File", f"{settings.BROKER_DIRECTORY.absolute()}/logs/broker.log")
 
         # Print the table
-        console = Console()
-        console.print(table)
+        CONSOLE.print(table)
 
 
 @loggedcli(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -475,12 +475,15 @@ def restore():
 
 @loggedcli(group=config)
 @click.argument("chunk", type=str, required=False)
-def init(chunk):
+@click.option("--from", "_from", type=str, help="A file path or URL to initialize the config from.")
+def init(chunk=None, _from=None):
     """Initialize the broker configuration file from your local clone or GitHub.
 
     You can also init specific chunks by passing the chunk name.
+    Additionally, if you want to initialize from a file or URL, you can pass the `--from` flag.
+    Keep in mind that the file and url contents need to be valid yaml.
     """
-    ConfigManager(settings.settings_path).init_config_file(chunk)
+    ConfigManager(settings.settings_path).init_config_file(chunk=chunk, _from=_from)
 
 
 @loggedcli(group=config)
@@ -503,9 +506,10 @@ def nick(nick, no_syntax):
 
 
 @loggedcli(group=config)
-def migrate():
+@click.option("-f", "--force-version", type=str, help="Force the migration to a specific version")
+def migrate(force_version=None):
     """Migrate the broker configuration file to the latest version."""
-    ConfigManager(settings.settings_path).migrate()
+    ConfigManager(settings.settings_path).migrate(force_version=force_version)
 
 
 @loggedcli(group=config)

--- a/broker/commands.py
+++ b/broker/commands.py
@@ -264,22 +264,22 @@ populate_providers(providers)
 
 
 @loggedcli()
-@click.argument("vm", type=str, nargs=-1)
+@click.argument("hosts", type=str, nargs=-1)
 @click.option("-b", "--background", is_flag=True, help="Run checkin in the background")
-@click.option("--all", "all_", is_flag=True, help="Select all VMs")
+@click.option("--all", "all_", is_flag=True, help="Select all hosts")
 @click.option("--sequential", is_flag=True, help="Run checkins sequentially")
 @click.option("--filter", type=str, help="Checkin only what matches the specified filter")
-def checkin(vm, background, all_, sequential, filter):
-    """Checkin or "remove" a VM or series of VM broker instances.
+def checkin(hosts, background, all_, sequential, filter):
+    """Checkin or "remove" a host or series of hosts.
 
-    COMMAND: broker checkin <vm hostname>|<local id>|--all
+    COMMAND: broker checkin <hostname>|<local id>|--all
     """
     if background:
         helpers.fork_broker()
     inventory = helpers.load_inventory(filter=filter)
     to_remove = []
     for num, host in enumerate(inventory):
-        if str(num) in vm or host.get("hostname") in vm or host.get("name") in vm or all_:
+        if str(num) in hosts or host.get("hostname") in hosts or host.get("name") in hosts or all_:
             to_remove.append(Broker().reconstruct_host(host))
     Broker(hosts=to_remove).checkin(sequential=sequential)
 
@@ -294,7 +294,7 @@ def checkin(vm, background, all_, sequential, filter):
 )
 @click.option("--filter", type=str, help="Display only what matches the specified filter")
 def inventory(details, curated, sync, filter):
-    """Get a list of all VMs you've checked out showing hostname and local id.
+    """Get a list of all hosts you've checked out showing hostname and local id.
 
     hostname pulled from list of dictionaries.
     """
@@ -332,9 +332,9 @@ def inventory(details, curated, sync, filter):
 
 
 @loggedcli()
-@click.argument("vm", type=str, nargs=-1)
+@click.argument("hosts", type=str, nargs=-1)
 @click.option("-b", "--background", is_flag=True, help="Run extend in the background")
-@click.option("--all", "all_", is_flag=True, help="Select all VMs")
+@click.option("--all", "all_", is_flag=True, help="Select all hosts")
 @click.option("--sequential", is_flag=True, help="Run extends sequentially")
 @click.option("--filter", type=str, help="Extend only what matches the specified filter")
 @click.option(
@@ -346,10 +346,10 @@ def inventory(details, curated, sync, filter):
     " labels (e.g. '-l k1=v1,k2=v2,k3=v3=z4').",
 )
 @provider_options
-def extend(vm, background, all_, sequential, filter, **kwargs):
+def extend(hosts, background, all_, sequential, filter, **kwargs):
     """Extend a host's lease time.
 
-    COMMAND: broker extend <vm hostname>|<vm name>|<local id>|--all
+    COMMAND: broker extend <hostname>|<host name>|<local id>|--all
     """
     broker_args = helpers.clean_dict(kwargs)
     if background:
@@ -357,7 +357,7 @@ def extend(vm, background, all_, sequential, filter, **kwargs):
     inventory = helpers.load_inventory(filter=filter)
     to_extend = []
     for num, host in enumerate(inventory):
-        if str(num) in vm or host["hostname"] in vm or host.get("name") in vm or all_:
+        if str(num) in hosts or host["hostname"] in hosts or host.get("name") in hosts or all_:
             to_extend.append(Broker().reconstruct_host(host))
     Broker(hosts=to_extend, **broker_args).extend(sequential=sequential)
 

--- a/broker/config_manager.py
+++ b/broker/config_manager.py
@@ -1,0 +1,280 @@
+"""Module providing the functionality powering the `broker config` command."""
+
+import importlib
+from importlib.metadata import version
+import inspect
+import json
+import os
+from pathlib import Path
+import pkgutil
+from tempfile import NamedTemporaryFile
+
+import click
+from logzero import logger
+from packaging.version import Version
+import yaml
+
+from broker import exceptions
+
+C_SEP = "."  # chunk separator
+GH_CFG = "https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example"
+
+
+def file_name_to_ver(file_name):
+    """Convert a version-encoded filename `v0_6_0` to a `Version` object."""
+    return Version(file_name[1:].replace("_", "."))
+
+
+def yaml_format(data):
+    """Format the data as yaml.
+
+    Duplicating here to avoid circular imports.
+    """
+    return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+
+class ConfigManager:
+    """Class to interact with Broker's configuration file.
+
+    One important concept of these commands is the concept of a "chunk".
+
+    A chunk is a part of the configuration file that can be accessed or updated.
+    Chunks are specified by their keys in the configuration file.
+    Nested chunks are separated by periods.
+
+    e.g. broker config view AnsibleTower.instances.my_instance
+    """
+
+    version = version("broker")
+
+    def __init__(self, settings_path=None):
+        self._interactive_mode = None
+        self._settings_path = settings_path
+        if settings_path:
+            if settings_path.exists():
+                self._cfg = yaml.safe_load(self._settings_path.read_text())
+            else:
+                click.secho(
+                    f"Broker settings file not found at {settings_path.absolute()}.", fg="red"
+                )
+                self.init_config_file()
+
+    @property
+    def interactive_mode(self):
+        """Determine if Broker is running in interactive mode."""
+        if self._interactive_mode is None:
+            self._interactive_mode = False
+            # GitHub action context
+            if "GITHUB_WORKFLOW" not in os.environ:
+                # determine if we're being ran from a CLI
+                for frame in inspect.stack()[::-1]:
+                    if "/bin/broker" in frame.filename:
+                        self._interactive_mode = True
+                        break
+        return self._interactive_mode
+
+    def _interactive_edit(self, chunk):
+        """Write the chunk data to a temporary file and open it in an editor."""
+        with NamedTemporaryFile(mode="w+", suffix=".yaml") as tmp:
+            tmp.write(yaml_format(chunk))
+            tmp.seek(0)
+            click.edit(filename=tmp.name)
+            tmp.seek(0)
+            new_data = tmp.read()
+        # first try to load it as yaml
+        try:
+            return yaml.safe_load(new_data)
+        except yaml.YAMLError:  # then try json
+            try:
+                return json.loads(new_data)
+            except json.JSONDecodeError:  # finally, just return the raw data
+                return new_data
+
+    def _import_config(self, source, is_url=False):
+        """Initialize the broker settings file from a source."""
+        proceed = True
+        if self.interactive_mode:
+            try:
+                proceed = click.confirm(f"Get example file from {source}?")
+            except click.core.Abort:
+                # We're likely in a different non-interactive environment (container?)
+                self._interactive_mode = False
+        if not proceed:
+            return
+        # get example file from source
+        if is_url:
+            import requests
+
+            click.echo(f"Downloading example file from: {source}")
+            return requests.get(source, timeout=60).text
+        else:
+            return source.read_text()
+
+    def _get_migrations(self):
+        """Construct a list of all applicable migrations."""
+        from broker import config_migrations
+
+        config_version = Version(self._cfg.get("_version", "0.0.0"))
+        migrations = []
+        for _, name, _ in pkgutil.iter_modules(config_migrations.__path__):
+            module = importlib.import_module(f"broker.config_migrations.{name}")
+            if hasattr(module, "run_migrations") and config_version < file_name_to_ver(name):
+                migrations.append(module)
+        return migrations
+
+    def backup(self):
+        """Backup the current configuration file."""
+        logger.debug(
+            f"Backing up the configuration file to {self._settings_path.with_suffix('.bak')}"
+        )
+        self._settings_path.with_suffix(".bak").write_text(self._settings_path.read_text())
+
+    def restore(self):
+        """Restore the configuration file from a backup if it exists."""
+        logger.debug(
+            f"Restoring the configuration file from {self._settings_path.with_suffix('.bak')}"
+        )
+        backup_path = self._settings_path.with_suffix(".bak")
+        if not backup_path.exists():
+            raise exceptions.UserError("No backup file found.")
+        self._settings_path.write_text(backup_path.read_text())
+
+    def edit(self, chunk=None, content=None):
+        """Open the config file in an editor."""
+        if not self.interactive_mode:
+            raise exceptions.UserError(
+                "Attempted to edit the config in non-interactive mode.\n"
+                "Did you mean to use the `set` method instead?"
+            )
+        content = content or self.get(chunk=chunk)
+        new_val = self._interactive_edit(content)
+        self.update(chunk, new_val)
+
+    def get(self, chunk=None, curr_chunk=None):
+        """Get a chunk of Broker's config or the whole config."""
+        if not curr_chunk:
+            curr_chunk = self._cfg
+        if not chunk:
+            return curr_chunk
+        if C_SEP in chunk:
+            curr, chunk = chunk.split(C_SEP, 1)
+            # curr = int(curr) if curr.isdigit() else curr
+            return self.get(chunk, curr_chunk=curr_chunk[curr])
+        else:
+            # chunk = int(chunk) if chunk.isdigit() else chunk
+            try:
+                return curr_chunk[chunk]
+            except KeyError:
+                raise exceptions.UserError(f"Chunk '{chunk}' not found in the config.")
+
+    def update(self, chunk, new_val, curr_chunk=None):
+        """Update a chunk of Broker's config or the whole config."""
+        # Recursive down to find the chunk to update, then propagate the new value back up
+        if not curr_chunk:  # we're at the top level, so update the config directly
+            if chunk is None:  # the whole config is being updated
+                self._cfg = new_val
+            elif C_SEP in chunk:  # the update needs to happen at a lower level
+                curr, chunk = chunk.split(C_SEP, 1)
+                self._cfg[curr] = self.update(chunk, new_val, curr_chunk=self._cfg[curr])
+            else:
+                self._cfg[chunk] = new_val
+            # update the config file if it exists
+            if self._settings_path.exists():
+                self.backup()
+            self._settings_path.write_text(
+                yaml.dump(self._cfg, default_flow_style=False, sort_keys=False)
+            )
+        else:  # we're not at the top level, so keep going down
+            if C_SEP in chunk:
+                curr, chunk = chunk.split(C_SEP, 1)
+                curr_chunk[curr] = self.update(chunk, new_val, curr_chunk=curr_chunk[curr])
+            else:
+                curr_chunk[chunk] = new_val
+            return curr_chunk
+
+    def nicks(self, nick=None):
+        """Get a list of nicks or single nick information."""
+        nicks = self.get("nicks")
+        if nick:
+            return nicks[nick]
+        return list(nicks.keys())
+
+    def init_config_file(self, chunk=None):
+        """Check for the existence of the config file and create it if it doesn't exist."""
+        if self.interactive_mode and self._settings_path.exists() and not chunk:
+            # if the file exists, ask the user if they want to overwrite it
+            if (
+                click.prompt(
+                    f"Settings file already exists at {self._settings_path.absolute()}. Overwrite?",
+                    type=click.Choice(["y", "n"]),
+                    default="n",
+                )
+                != "y"
+            ):
+                return
+        # get the example file from the local repo or GitHub
+        example_path = Path(__file__).parent.parent.joinpath("broker_settings.yaml.example")
+        raw_data = None
+        if example_path.exists():
+            raw_data = self._import_config(example_path)
+        if not raw_data:
+            raw_data = self._import_config(GH_CFG, is_url=True)
+        if not raw_data:
+            raise exceptions.ConfigurationError(
+                f"Broker settings file not found at {self._settings_path.absolute()}."
+            )
+        chunk_data = self.get(chunk, yaml.safe_load(raw_data))
+        if self.interactive_mode:
+            chunk_data = self._interactive_edit(chunk_data)
+        self.update(chunk, chunk_data)
+
+    def migrate(self):
+        """Migrate the config from a previous version of Broker."""
+        # get all available migrations
+        if not (migrations := self._get_migrations()):
+            logger.info("No migrations are applicable to your config.")
+            return
+        # run all migrations in order
+        working_config = self._cfg
+        for migration in sorted(migrations, key=lambda m: m.TO_VERSION):
+            working_config = migration.run_migrations(working_config)
+        self.backup()
+        self._settings_path.write_text(
+            yaml.dump(working_config, default_flow_style=False, sort_keys=False)
+        )
+        logger.info("Config migration complete.")
+
+    def validate(self, chunk, providers=None):
+        """Validate a top-level chunk of Broker's config."""
+        if "." in chunk:  # only validate the top-level chunk
+            chunk = chunk.split(".")[0]
+        if chunk.lower() == "base":  # validate the base config
+            return  # this happens before we're called
+        if chunk.lower() == "ssh":
+            from broker.settings import settings
+
+            settings.validators.validate(only="SSH")
+            return
+        if providers is None:
+            raise exceptions.UserError(
+                "Attempted to validate provider settings without passing providers."
+            )
+        if ":" in chunk:
+            prov_name, instance = chunk.split(":")
+            providers[prov_name](**{prov_name: instance})
+        if chunk == "all":
+            for prov_name, prov_cls in providers.items():
+                if prov_name == "TestProvider":
+                    continue
+                logger.info(f"Validating {prov_name} provider settings.")
+                try:  # we want to suppress all exceptions here to allow each provider to validate
+                    prov_cls()
+                except Exception as err:  # noqa: BLE001
+                    logger.warning(f"Provider {prov_name} failed validation: {err}")
+            return
+        if chunk not in providers:
+            raise exceptions.UserError(
+                "I don't know how to validate that.\n"
+                "If it's important, it is likely covered in the base validations."
+            )
+        providers[chunk]()

--- a/broker/config_migrations/v0_6_0.py
+++ b/broker/config_migrations/v0_6_0.py
@@ -1,0 +1,72 @@
+"""Config migrations for versions older than 0.6.0 to 0.6.0."""
+from logzero import logger
+
+TO_VERSION = "0.6.0"
+
+
+def migrate_instances(config_dict):
+    """Migrate instances from a list of dicts to a dict of dicts."""
+    logger.debug("Migrating instances from a list to a dict.")
+    for key, val in config_dict.items():
+        if not isinstance(val, dict):
+            continue
+        if "instances" in val and isinstance(val["instances"], list):
+            old_instances = val.pop("instances")
+            val["instances"] = {}
+            for inst in old_instances:
+                val["instances"].update(inst)
+        config_dict[key] = val
+    return config_dict
+
+
+def remove_testprovider(config_dict):
+    """Remove the testprovider from the config."""
+    logger.debug("Removing the testprovider from the config.")
+    config_dict.pop("TestProvider", None)
+    return config_dict
+
+
+def remove_test_nick(config_dict):
+    """Remove the test nick from the config."""
+    logger.debug("Removing the test nick from the config.")
+    nicks = config_dict.get("nicks", {})
+    nicks.pop("test_nick", None)
+    config_dict["nicks"] = nicks
+    return config_dict
+
+
+def move_ssh_settings(config_dict):
+    """Move SSH settings from the top leve into its own chunk."""
+    logger.debug("Moving SSH settings into their own section.")
+    ssh_settings = {
+        "backend": config_dict.pop("ssh_backend", "ssh2-python312"),
+        "host_username": config_dict.pop("host_username", "root"),
+        "host_password": config_dict.pop("host_password", "toor"),
+        "host_ipv6": config_dict.pop("host_ipv6", False),
+        "host_ipv4_fallback": config_dict.pop("host_ipv4_fallback", True),
+    }
+    if ssh_port := config_dict.pop("host_ssh_port", None):
+        ssh_settings["ssh_port"] = ssh_port
+    if ssh_key := config_dict.pop("host_ssh_key_filename", None):
+        ssh_settings["host_ssh_key_filename"] = ssh_key
+    config_dict["ssh"] = ssh_settings
+    return config_dict
+
+
+def add_thread_limit(config_dict):
+    """Add a thread limit to the config."""
+    logger.debug("Adding a thread limit to the config.")
+    config_dict["thread_limit"] = None
+    return config_dict
+
+
+def run_migrations(config_dict):
+    """Run all migrations."""
+    logger.info(f"Running config migrations for {TO_VERSION}.")
+    config_dict = migrate_instances(config_dict)
+    config_dict = remove_testprovider(config_dict)
+    config_dict = remove_test_nick(config_dict)
+    config_dict = move_ssh_settings(config_dict)
+    config_dict = add_thread_limit(config_dict)
+    config_dict["_version"] = TO_VERSION
+    return config_dict

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -458,19 +458,20 @@ def fork_broker():
 def handle_keyboardinterrupt(*args):
     """Handle keyboard interrupts gracefully.
 
-    Offer the user a choice between keeping Broker alive in the background or killing it.
+    Offer the user a choice between keeping Broker alive in the background, killing it, or resuming execution.
     """
     choice = click.prompt(
-        "\nEnding Broker while running won't end processes being monitored.\n"
-        "Would you like to switch Broker to run in the background?\n"
-        "[y/n]: ",
-        type=click.Choice(["y", "n"]),
-        default="n",
-    )
-    if choice == "y":
+        "\nEnding Broker while running may not end processes being monitored.\n"
+        "Would you like to switch Broker to run in the Background, Kill it, or Resume execution?\n",
+        type=click.Choice(["b", "k", "r"]),
+        default="r",
+    ).lower()
+    if choice == "b":
         fork_broker()
-    else:
+    elif choice == "k":
         raise exceptions.BrokerError("Broker killed by user.")
+    elif choice == "r":
+        click.echo("Resuming execution...")
 
 
 def translate_timeout(timeout):

--- a/broker/session.py
+++ b/broker/session.py
@@ -19,7 +19,7 @@ from broker.exceptions import NotImplementedError
 from broker.settings import settings
 
 SSH_BACKENDS = ("ssh2-python", "ssh2-python312", "ansible-pylibssh", "hussh")
-SSH_BACKEND = settings.SSH_BACKEND
+SSH_BACKEND = settings.BACKEND
 
 logger.debug(f"{SSH_BACKEND=}")
 

--- a/broker/session.py
+++ b/broker/session.py
@@ -8,6 +8,7 @@ Classes:
 Note: You typically want to use a Host object instance to create sessions,
       not these classes directly.
 """
+
 from contextlib import contextmanager
 from pathlib import Path
 import tempfile
@@ -19,7 +20,7 @@ from broker.exceptions import NotImplementedError
 from broker.settings import settings
 
 SSH_BACKENDS = ("ssh2-python", "ssh2-python312", "ansible-pylibssh", "hussh")
-SSH_BACKEND = settings.BACKEND
+SSH_BACKEND = settings.SSH.BACKEND
 
 logger.debug(f"{SSH_BACKEND=}")
 

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -10,9 +10,9 @@ Useful items:
     settings_path: The path to the settings file.
     inventory_path: The path to the inventory file.
 """
+
 import os
 from pathlib import Path
-import sys
 
 import click
 from dynaconf import Dynaconf, Validator
@@ -21,9 +21,9 @@ from dynaconf.validator import ValidationError
 from broker.config_manager import ConfigManager
 from broker.exceptions import ConfigurationError
 
-INTERACTIVE_MODE = ConfigManager().interactive_mode
+INTERACTIVE_MODE = ConfigManager.interactive_mode
 BROKER_DIRECTORY = Path.home().joinpath(".broker")
-TEST_MODE = "pytest" in sys.modules
+TEST_MODE = os.environ.get("BROKER_TEST_MODE", False)
 
 if TEST_MODE:  # when in test mode, don't use the real broker directory
     BROKER_DIRECTORY = Path("tests/data/")

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,19 +1,24 @@
 # Broker settings
+_version: 0.6.0
 # different log levels for file and stdout
 logging:
     console_level: info
     file_level: debug
-# Host Settings
+# Optionally set a limit for the number of threads Broker can use for actions
+thread_limit: None
+# Host SSH Settings
 # These can be left alone if you're not using Broker as a library
-host_username: root
-host_password: "<password>"
-host_ssh_port: 22
-host_ssh_key_filename: "</path/to/the/ssh-key>"
-# Default all host ssh connections to IPv6
-host_ipv6: False
-# If IPv6 connection attempts fail, fallback to IPv4
-host_ipv4_fallback: True
-ssh_backend: ssh2-python312
+ssh:
+    # this is the library Broker should use to perform ssh actions
+    backend: ssh2-python312
+    host_username: root
+    host_password: "<password>"
+    host_ssh_port: 22
+    host_ssh_key_filename: "</path/to/the/ssh-key>"
+    # Default all host ssh connections to IPv6
+    host_ipv6: False
+    # If IPv6 connection attempts fail, fallback to IPv4
+    host_ipv4_fallback: True
 # Provider settings
 AnsibleTower:
     base_url: "https://<ansible tower host>/"
@@ -30,14 +35,14 @@ AnsibleTower:
     results_limit: 50
 Container:
     instances:
-        - docker:
+        docker:
             host_username: "<username>"
             host_password: "<plain text password>"
             host_port: None
             runtime: docker
             network: null
             default: True
-        - remote:
+        remote:
             host: "<remote hostname>"
             host_username: "<username>"
             host_password: "<plain text password>"
@@ -49,7 +54,7 @@ Container:
     auto_map_ports: False
 Foreman:
   instances:
-    - foreman1:
+    foreman1:
         foreman_url: https://test.fore.man
         foreman_username: admin
         foreman_password: secret
@@ -57,7 +62,7 @@ Foreman:
         location: LOC
         verify: ./ca.crt
         default: true
-    - foreman2:
+    foreman2:
         foreman_url: https://other-test.fore.man
         foreman_username: admin
         foreman_password: secret
@@ -67,25 +72,9 @@ Foreman:
 Beaker:
     hub_url:
     max_job_wait: 24h
-TestProvider:
-    instances:
-        - test1:
-            foo: "bar"
-            default: True
-        - test2:
-            foo: "baz"
-            override_envars: True
-        - bad:
-            nothing: False
-    config_value: "something"
 # You can set a nickname as a shortcut for arguments
 nicks:
-    rhel7:
-        workflow: "deploy-rhel"
-        deploy_rhel_version: "7.9"
+    rhel9:
+        workflow: deploy-rhel
+        deploy_rhel_version: 9.4
         notes: "Requested by broker"
-    test_nick:
-        test_action: "fake"
-        arg1: "abc"
-        arg2: 123
-        arg3: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ description = "The infrastructure middleman."
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["broker", "AnsibleTower", "docker", "podman", "beaker"]
-authors = [
-    {name = "Jacob J Callahan", email = "jacob.callahan05@gmail.com"}
-]
+authors = [{ name = "Jacob J Callahan", email = "jacob.callahan05@gmail.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -27,33 +25,25 @@ dependencies = [
     "dynaconf<4.0.0",
     "logzero",
     "packaging",
-    "pyyaml",
     "rich",
     "rich_click",
+    "ruamel.yaml",
     "setuptools",
     "ssh2-python312",
 ]
-dynamic = ["version"]  # dynamic fields to update on build - version via setuptools_scm
+dynamic = [
+    "version",
+] # dynamic fields to update on build - version via setuptools_scm
 
 [project.urls]
 Repository = "https://github.com/SatelliteQE/broker"
 
 [project.optional-dependencies]
 beaker = ["beaker-client"]
-dev = [
-    "pre-commit",
-    "pytest",
-    "ruff"
-]
-docker = [
-    "docker",
-    "paramiko"
-]
+dev = ["pre-commit", "pytest", "ruff"]
+docker = ["docker", "paramiko"]
 podman = ["podman>=5.2"]
-setup = [
-    "build",
-    "twine",
-]
+setup = ["build", "twine"]
 
 ssh2_py311 = ["ssh2-python"]
 ssh2_python = ["ssh2-python"]
@@ -72,7 +62,7 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["broker"]
 
-[tool.setuptools_scm]  # same as use_scm_version=True in setup.py
+[tool.setuptools_scm] # same as use_scm_version=True in setup.py
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -85,82 +75,82 @@ target-version = "py311"
 fixable = ["ALL"]
 
 select = [
-    "B002", # Python does not support the unary prefix increment
-    "B007", # Loop control variable {name} not used within loop body
-    "B009", # Do not call getattr with a constant attribute value
-    "B010", # Do not call setattr with a constant attribute value
-    "B011", # Do not `assert False`, raise `AssertionError` instead
-    "B013", # Redundant tuple in exception handler
-    "B014", # Exception handler with duplicate exception
-    "B023", # Function definition does not bind loop variable {name}
-    "B026", # Star-arg unpacking after a keyword argument is strongly discouraged
-    "BLE001", # Using bare except clauses is prohibited
-    "C", # complexity
-    "C4", # flake8-comprehensions
-    "COM818", # Trailing comma on bare tuple prohibited
-    "D", # docstrings
-    "E", # pycodestyle
-    "F", # pyflakes/autoflake
-    "G", # flake8-logging-format
-    "I", # isort
-    "ISC001", # Implicitly concatenated string literals on one line
-    "N804", # First argument of a class method should be named cls
-    "N805", # First argument of a method should be named self
-    "N815", # Variable {name} in class scope should not be mixedCase
-    "N999", # Invalid module name: '{name}'
-    "PERF", # Perflint rules
-    "PGH004", # Use specific rule codes when using noqa
+    "B002",    # Python does not support the unary prefix increment
+    "B007",    # Loop control variable {name} not used within loop body
+    "B009",    # Do not call getattr with a constant attribute value
+    "B010",    # Do not call setattr with a constant attribute value
+    "B011",    # Do not `assert False`, raise `AssertionError` instead
+    "B013",    # Redundant tuple in exception handler
+    "B014",    # Exception handler with duplicate exception
+    "B023",    # Function definition does not bind loop variable {name}
+    "B026",    # Star-arg unpacking after a keyword argument is strongly discouraged
+    "BLE001",  # Using bare except clauses is prohibited
+    "C",       # complexity
+    "C4",      # flake8-comprehensions
+    "COM818",  # Trailing comma on bare tuple prohibited
+    "D",       # docstrings
+    "E",       # pycodestyle
+    "F",       # pyflakes/autoflake
+    "G",       # flake8-logging-format
+    "I",       # isort
+    "ISC001",  # Implicitly concatenated string literals on one line
+    "N804",    # First argument of a class method should be named cls
+    "N805",    # First argument of a method should be named self
+    "N815",    # Variable {name} in class scope should not be mixedCase
+    "N999",    # Invalid module name: '{name}'
+    "PERF",    # Perflint rules
+    "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
-    "PLC", # pylint
-    "PLE", # pylint
-    "PLR", # pylint
-    "PLW", # pylint
-    "PTH", # Use pathlib
-    "RUF", # Ruff-specific rules
-    "S103", # bad-file-permissions
-    "S108", # hardcoded-temp-file
-    "S110", # try-except-pass
-    "S112", # try-except-continue
-    "S113", # Probable use of requests call without timeout
-    "S306", # suspicious-mktemp-usage
-    "S307", # suspicious-eval-usage
-    "S601", # paramiko-call
-    "S602", # subprocess-popen-with-shell-equals-true
-    "S604", # call-with-shell-equals-true
-    "S609", # unix-command-wildcard-injection
-    "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
-    "SIM117", # Merge with-statements that use the same scope
-    "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
-    "SIM201", # Use {left} != {right} instead of not {left} == {right}
-    "SIM208", # Use {expr} instead of not (not {expr})
-    "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
-    "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
-    "SIM401", # Use get from dict with default instead of an if block
-    "T100", # Trace found: {name} used
-    "T20", # flake8-print
-    "TRY004", # Prefer TypeError exception for invalid type
-    "TRY302", # Remove exception handler; error is immediately re-raised
+    "PLC",     # pylint
+    "PLE",     # pylint
+    "PLR",     # pylint
+    "PLW",     # pylint
+    "PTH",     # Use pathlib
+    "RUF",     # Ruff-specific rules
+    "S103",    # bad-file-permissions
+    "S108",    # hardcoded-temp-file
+    "S110",    # try-except-pass
+    "S112",    # try-except-continue
+    "S113",    # Probable use of requests call without timeout
+    "S306",    # suspicious-mktemp-usage
+    "S307",    # suspicious-eval-usage
+    "S601",    # paramiko-call
+    "S602",    # subprocess-popen-with-shell-equals-true
+    "S604",    # call-with-shell-equals-true
+    "S609",    # unix-command-wildcard-injection
+    "SIM105",  # Use contextlib.suppress({exception}) instead of try-except-pass
+    "SIM117",  # Merge with-statements that use the same scope
+    "SIM118",  # Use {key} in {dict} instead of {key} in {dict}.keys()
+    "SIM201",  # Use {left} != {right} instead of not {left} == {right}
+    "SIM208",  # Use {expr} instead of not (not {expr})
+    "SIM212",  # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
+    "SIM300",  # Yoda conditions. Use 'age == 42' instead of '42 == age'.
+    "SIM401",  # Use get from dict with default instead of an if block
+    "T100",    # Trace found: {name} used
+    "T20",     # flake8-print
+    "TRY004",  # Prefer TypeError exception for invalid type
+    "TRY302",  # Remove exception handler; error is immediately re-raised
     "PLR0911", # Too many return statements ({returns} > {max_returns})
     "PLR0912", # Too many branches ({branches} > {max_branches})
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
-    "UP", # pyupgrade
-    "W", # pycodestyle
+    "UP",      # pyupgrade
+    "W",       # pycodestyle
 ]
 
 ignore = [
-    "ANN", # flake8-annotations
-    "D203", # 1 blank line required before class docstring
-    "D213", # Multi-line docstring summary should start at the second line
-    "D406", # Section name should end with a newline
-    "D407", # Section name underlining
-    "D413", # Missing blank line after last section
-    "E501", # line too long
-    "E731", # do not assign a lambda expression, use a def
+    "ANN",     # flake8-annotations
+    "D203",    # 1 blank line required before class docstring
+    "D213",    # Multi-line docstring summary should start at the second line
+    "D406",    # Section name should end with a newline
+    "D407",    # Section name underlining
+    "D413",    # Missing blank line after last section
+    "E501",    # line too long
+    "E731",    # do not assign a lambda expression, use a def
     "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
-    "RUF012", # Mutable class attributes should be annotated with typing.ClassVar
-    "D107", # Missing docstring in __init__
+    "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
+    "D107",    # Missing docstring in __init__
 ]
 
 [tool.ruff.flake8-pytest-style]
@@ -168,9 +158,7 @@ fixture-parentheses = false
 
 [tool.ruff.isort]
 force-sort-within-sections = true
-known-first-party = [
-    "broker",
-]
+known-first-party = ["broker"]
 combine-as-imports = true
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "packaging",
     "pyyaml",
     "rich",
+    "rich_click",
     "setuptools",
     "ssh2-python312",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import os
 import pytest
 
 
+def pytest_sessionstart(session):
+    """Put Broker into test mode."""
+    os.environ["BROKER_TEST_MODE"] = "True"
+
+
 @pytest.fixture
 def set_envars(request):
     """Set and unset one or more environment variables"""

--- a/tests/data/broker_settings.yaml
+++ b/tests/data/broker_settings.yaml
@@ -1,0 +1,59 @@
+_version: 0.6.0
+logging:
+  console_level: info
+  file_level: debug
+ssh:
+  backend: ssh2-python312
+  host_username: root
+  host_password: <password>
+  host_ssh_port: 22
+  host_ssh_key_filename: </path/to/the/ssh-key>
+  host_ipv6: false
+  host_ipv4_fallback: true
+AnsibleTower:
+  base_url: https://<ansible tower host>/
+  username: <username>
+  token: <AT personal access token>
+  release_workflow: remove-vm
+  extend_workflow: extend-vm
+  new_expire_time: '+172800'
+  workflow_timeout: 3600
+  results_limit: 50
+Container:
+  host_username: <username>
+  host_password: <plain text password>
+  host_port: None
+  network: null
+  default: true
+  runtime: podman
+  results_limit: 50
+  auto_map_ports: false
+Foreman:
+  foreman_url: https://test.fore.man
+  foreman_username: admin
+  foreman_password: secret
+  organization: ORG
+  location: LOC
+  verify: ./ca.crt
+  name_prefix: broker
+Beaker:
+  hub_url: null
+  max_job_wait: 24h
+TestProvider:
+    instances:
+        test1:
+            foo: "bar"
+            default: True
+        test2:
+            foo: "baz"
+            override_envars: True
+        bad:
+            nothing: False
+    config_value: "something"
+# You can set a nickname as a shortcut for arguments
+nicks:
+    test_nick:
+        test_action: "fake"
+        arg1: "abc"
+        arg2: 123
+        arg3: True

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -20,13 +20,10 @@ def skip_if_not_configured():
 
 
 @pytest.fixture(scope="module")
-def temp_inventory():
-    """Temporarily move the local inventory, then move it back when done"""
-    backup_path = inventory_path.rename(f"{inventory_path.absolute()}.bak")
+def checkin_containers():
+    """Checkin all containers checkout out by the tests."""
     yield
     CliRunner().invoke(cli, ["checkin", "--all", "--filter", "_broker_provider<Container"])
-    inventory_path.unlink()
-    backup_path.rename(inventory_path)
 
 
 # ----- CLI Scenario Tests -----
@@ -35,7 +32,7 @@ def temp_inventory():
 @pytest.mark.parametrize(
     "args_file", [f for f in SCENARIO_DIR.iterdir() if f.name.startswith("checkout_")], ids=lambda f: f.name.split(".")[0]
 )
-def test_checkout_scenarios(args_file, temp_inventory):
+def test_checkout_scenarios(args_file, checkin_containers):
     result = CliRunner().invoke(cli, ["checkout", "--args-file", args_file])
     assert result.exit_code == 0
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -3,15 +3,6 @@ from broker.providers import test_provider
 import pytest
 
 
-@pytest.fixture(scope="module")
-def temp_inventory():
-    """Temporarily move the local inventory, then move it back when done"""
-    backup_path = settings.inventory_path.rename(f"{settings.inventory_path.absolute()}.bak")
-    yield
-    settings.inventory_path.unlink()
-    backup_path.rename(settings.inventory_path)
-
-
 def test_empty_init():
     """Broker should be able to init without any arguments"""
     broker_inst = Broker()
@@ -66,7 +57,7 @@ def test_broker_empty_checkin():
     broker_inst.checkin()
 
 
-def test_broker_checkin_n_sync_empty_hostname(temp_inventory):
+def test_broker_checkin_n_sync_empty_hostname():
     """Test that broker can checkin and sync inventory with a host that has empty hostname"""
     broker_inst = broker.Broker(nick="test_nick")
     broker_inst.checkout()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,9 +1,11 @@
 """Test file for broker.config_manager module."""
-import yaml
+from ruamel.yaml import YAML
 from broker.config_manager import ConfigManager, GH_CFG
 from broker.settings import settings_path
 
-TEST_CFG_DATA = yaml.safe_load(settings_path.read_text())
+
+yaml = YAML()
+TEST_CFG_DATA = yaml.load(settings_path)
 
 
 def test_basic_assertions():
@@ -19,7 +21,7 @@ def test_import_config():
     cfg_mgr = ConfigManager()
     result = cfg_mgr._import_config(GH_CFG, is_url=True)
     assert isinstance(result, str)
-    converted = yaml.safe_load(result)
+    converted = yaml.load(result)
     assert isinstance(converted, dict)
 
 def test_get_e2e():

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,60 @@
+"""Test file for broker.config_manager module."""
+import yaml
+from broker.config_manager import ConfigManager, GH_CFG
+from broker.settings import settings_path
+
+TEST_CFG_DATA = yaml.safe_load(settings_path.read_text())
+
+
+def test_basic_assertions():
+    """Test ConfigManager class initialization and basic attributes."""
+    cfg_mgr = ConfigManager(settings_path)
+    assert isinstance(cfg_mgr._cfg, dict)
+    assert cfg_mgr._cfg == TEST_CFG_DATA
+    assert cfg_mgr.interactive_mode is False
+
+
+def test_import_config():
+    """ConfigManager should be able to download examples settings."""
+    cfg_mgr = ConfigManager()
+    result = cfg_mgr._import_config(GH_CFG, is_url=True)
+    assert isinstance(result, str)
+    converted = yaml.safe_load(result)
+    assert isinstance(converted, dict)
+
+def test_get_e2e():
+    """We should be able to get config chunks."""
+    cfg_mgr = ConfigManager(settings_path)
+    whole_cfg = cfg_mgr.get()
+    assert isinstance(whole_cfg, dict)
+    assert whole_cfg == TEST_CFG_DATA
+    # get a speficic chunk
+    logging_cfg = cfg_mgr.get('logging')
+    assert logging_cfg == TEST_CFG_DATA['logging']
+    # get a nested chunk
+    test_nick = cfg_mgr.get('nicks.test_nick')
+    assert test_nick == TEST_CFG_DATA['nicks']['test_nick']
+
+
+def test_update_e2e():
+    """We should be able to update config chunks."""
+    cfg_mgr = ConfigManager(settings_path)
+    # change logging level
+    cfg_mgr.update('logging.console_level', 'debug')
+    assert cfg_mgr.get('logging.console_level') == 'debug'
+    # ensure a backup was created
+    assert settings_path.with_suffix('.bak').exists()
+    # restore original config and make sure the value is reverted
+    cfg_mgr.restore()
+    # load a new instance of ConfigManager to ensure the change was reverted
+    cfg_mgr = ConfigManager(settings_path)
+    assert cfg_mgr.get('logging.console_level') == TEST_CFG_DATA['logging']['console_level']
+
+
+def test_nicks():
+    """Specifically test the nick functionality."""
+    cfg_mgr = ConfigManager(settings_path)
+    nick_list = cfg_mgr.nicks()
+    assert "test_nick" in nick_list
+    test_nick = cfg_mgr.nicks("test_nick")
+    assert test_nick == TEST_CFG_DATA['nicks']['test_nick']


### PR DESCRIPTION
The initial change of this was to introduce the broker config cli. However, to do this, a number of supporting and related changes needed to be made.

The first of these is the new ConfigManager class that manages reading from and writing to the config file.
Since so much logic was implemented for this, it made more sense to roll in the import/init functionality, that was originally in the settings module, into the new class.

This also gave me the opportunity to separate the test config from the example config. This removal, and other changes in this were supported by ConfigManager's migration functionality.

To simplify the nested chunk notation, I moved provider instances out from a list to just being a nested dictionary. This actually simplified the instance logic quite a bit.

Related to config simlification was the separation of the host settings to a new ssh chunk of the config. This is because not all users use the host functionality Broker provides. A likely change with this release is going to be removing a default ssh backend from Broker's requirements.

While I was at it, I also switched the CLI over to rich-click as part of a larger effort to improve the CLI experience.