### PR TITLE
Better handling for providers in concurrent actions

### DIFF
--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -130,22 +130,3 @@ def test_multi_manager():
 
 class SomeException(Exception):
     pass
-
-
-class MyBroker:
-    @broker.mp_decorator
-    def workload(self):
-        return []
-
-    @broker.mp_decorator
-    def failing_workload(self):
-        raise SomeException()
-
-
-def test_mp_decorator():
-    tested_broker = MyBroker()
-    tested_broker._kwargs = dict(_count=2)
-
-    tested_broker.workload()
-    with pytest.raises(SomeException):
-        tested_broker.failing_workload()


### PR DESCRIPTION
--- First Commit ---
This change simplifies the way we add provider validators to dynaconf. Instead of attempting to add new validators when a class instance is created, we instead add it when the class itself is created. This means that it will happen once immediately when broker is loaded.

--- Second Commit ---
This change rewrites the way broker actions handle concurrency.
Previously, this was offloaded in a manner that was wasteful in the way
it handled pre-action setup.
Now, we don't go concurrent until we're ready to perform the action we
want.