### PR TITLE
Enable timeouts for command execution when using Hussh

### DIFF
--- a/broker/binds/hussh.py
+++ b/broker/binds/hussh.py
@@ -91,9 +91,7 @@ class Session:
 
     def run(self, command, timeout=0):
         """Run a command on the host and return the results."""
-        # TODO support timeout parameter
-        result = self.session.execute(command)
-
+        result = self.session.execute(command, timeout=helpers.translate_timeout(timeout))
         # Create broker Result from hussh SSHResult
         return helpers.Result(
             status=result.status,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ ssh2_py311 = ["ssh2-python"]
 ssh2_python = ["ssh2-python"]
 ssh2_python312 = ["ssh2-python312"]
 ansible_pylibssh = ["ansible-pylibssh"]
-hussh = ["hussh"]
+hussh = ["hussh>=0.1.7"]
 
 [project.scripts]
 broker = "broker.commands:cli"


### PR DESCRIPTION
Previosuly it was impossible to set command-level timeouts when using Hussh as the backend. In fact, due to the way the Host objects acquired their Hussh connections, timeouts were always left to the default. Now, with Hussh 0.1.7, we can pass a command-specific timeout.

Hussh PR for Reference: https://github.com/JacobCallahan/Hussh/pull/14