### PR TITLE
Rework inventory cli

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -17,7 +17,7 @@ from broker.logger import LOG_LEVEL
 from broker.providers import PROVIDER_ACTIONS, PROVIDER_HELP, PROVIDERS
 
 signal.signal(signal.SIGINT, helpers.handle_keyboardinterrupt)
-CONSOLE = Console()  # rich console for pretty printing
+CONSOLE = Console(no_color=settings.settings.less_colors)  # rich console for pretty printing
 
 click.rich_click.SHOW_ARGUMENTS = True
 click.rich_click.COMMAND_GROUPS = {

--- a/broker/config_migrations/v0_6_0.py
+++ b/broker/config_migrations/v0_6_0.py
@@ -84,6 +84,13 @@ def add_inventory_fields(config_dict):
     return config_dict
 
 
+def add_color_control(config_dict):
+    """Add in the new `less_colors` field."""
+    logger.debug("Adding the less_colors field to the config.")
+    config_dict["less_colors"] = config_dict.get("less_colors", False)
+    return config_dict
+
+
 def run_migrations(config_dict):
     """Run all migrations."""
     logger.info(f"Running config migrations for {TO_VERSION}.")
@@ -93,5 +100,6 @@ def run_migrations(config_dict):
     config_dict = move_ssh_settings(config_dict)
     config_dict = add_thread_limit(config_dict)
     config_dict = add_inventory_fields(config_dict)
+    config_dict = add_color_control(config_dict)
     config_dict["_version"] = TO_VERSION
     return config_dict

--- a/broker/config_migrations/v0_6_0.py
+++ b/broker/config_migrations/v0_6_0.py
@@ -1,4 +1,5 @@
 """Config migrations for versions older than 0.6.0 to 0.6.0."""
+
 from logzero import logger
 
 TO_VERSION = "0.6.0"
@@ -60,6 +61,29 @@ def add_thread_limit(config_dict):
     return config_dict
 
 
+def add_inventory_fields(config_dict):
+    """Inventory fields are new in this version.
+
+    Example:
+        # Customize the fields and values presented by `broker inventory`
+        # Almost all field values should correspond to a field in your Broker inventory
+        inventory_fields:
+        Host: hostname | name  # use a | to allow fallback values
+        Provider: _broker_provider  # just pull the _broker_provider value
+        Action: $action  # some special field values are possible, check the wiki
+        OS: os_distribution os_distribution_version  # you can combine multiple values with a space between
+    """
+    logger.debug("Adding inventory fields to the config.")
+    config_dict["inventory_fields"] = {
+        "Host": "hostname",
+        "Provider": "_broker_provider",
+        "Action": "$action",
+        "OS": "os_distribution os_distribution_version",
+    }
+    config_dict["inventory_list_vars"] = "hostname | name"
+    return config_dict
+
+
 def run_migrations(config_dict):
     """Run all migrations."""
     logger.info(f"Running config migrations for {TO_VERSION}.")
@@ -68,5 +92,6 @@ def run_migrations(config_dict):
     config_dict = remove_test_nick(config_dict)
     config_dict = move_ssh_settings(config_dict)
     config_dict = add_thread_limit(config_dict)
+    config_dict = add_inventory_fields(config_dict)
     config_dict["_version"] = TO_VERSION
     return config_dict

--- a/broker/config_migrations/v0_6_0.py
+++ b/broker/config_migrations/v0_6_0.py
@@ -37,7 +37,10 @@ def remove_test_nick(config_dict):
 
 
 def move_ssh_settings(config_dict):
-    """Move SSH settings from the top leve into its own chunk."""
+    """Move SSH settings from the top level into its own chunk."""
+    # Check if the migration has already been performed
+    if "ssh" in config_dict:
+        return config_dict
     logger.debug("Moving SSH settings into their own section.")
     ssh_settings = {
         "backend": config_dict.pop("ssh_backend", "ssh2-python312"),
@@ -57,7 +60,7 @@ def move_ssh_settings(config_dict):
 def add_thread_limit(config_dict):
     """Add a thread limit to the config."""
     logger.debug("Adding a thread limit to the config.")
-    config_dict["thread_limit"] = None
+    config_dict["thread_limit"] = config_dict.get("thread_limit")
     return config_dict
 
 
@@ -73,6 +76,8 @@ def add_inventory_fields(config_dict):
         Action: $action  # some special field values are possible, check the wiki
         OS: os_distribution os_distribution_version  # you can combine multiple values with a space between
     """
+    if "inventory_fields" in config_dict:
+        return config_dict
     logger.debug("Adding inventory fields to the config.")
     config_dict["inventory_fields"] = {
         "Host": "hostname",

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -306,7 +306,7 @@ def inventory_fields_to_dict(inventory_fields, host_dict, **extras):
     {
         "Host": "some.test.host",
         "Provider": "AnsibleTower",
-        "Action": "deploy-base-rhel",
+        "Action": "deploy-rhel",
         "OS": "RHEL 8.4"
     }
 

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -328,7 +328,7 @@ def _resolve_inv_field(field, host_dict, **extras):
     if "|" in field:
         resolved = [_resolve_inv_field(f.strip(), host_dict, **extras) for f in field.split("|")]
         for val in resolved:
-            if val:
+            if val and val != "Unknown":
                 return val
         return "Unknown"
     # Users can combine multiple values in a single field, so evaluate each

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -78,6 +78,7 @@ validators = [
     Validator("THREAD_LIMIT", default=None),
     Validator("INVENTORY_FIELDS", is_type_of=dict),
     Validator("INVENTORY_LIST_VARS", is_type_of=str, default="hostname | name"),
+    Validator("LESS_COLORS", default=False),
 ]
 
 # temporary fix for dynaconf #751

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -76,6 +76,8 @@ validators = [
         default="debug",
     ),
     Validator("THREAD_LIMIT", default=None),
+    Validator("INVENTORY_FIELDS", is_type_of=dict),
+    Validator("INVENTORY_LIST_VARS", is_type_of=str, default="hostname | name"),
 ]
 
 # temporary fix for dynaconf #751

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -16,7 +16,7 @@ inventory_fields:
 # Much like you can set a variable lookup order for inventory fields
 inventory_list_vars: hostname | name | ip
 # Optionally set a limit for the number of threads Broker can use for actions
-thread_limit: None
+thread_limit: null
 # Host SSH Settings
 # These can be left alone if you're not using Broker as a library
 ssh:
@@ -49,7 +49,7 @@ Container:
         docker:
             host_username: "<username>"
             host_password: "<plain text password>"
-            host_port: None
+            host_port: null
             runtime: docker
             network: null
             default: True

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -4,6 +4,15 @@ _version: 0.6.0
 logging:
     console_level: info
     file_level: debug
+# Customize the fields and values presented by `broker inventory`
+# Almost all field values should correspond to a field in your Broker inventory
+inventory_fields:
+  Host: hostname | name  # use a | to allow fallback values
+  Provider: _broker_provider  # just pull the _broker_provider value
+  Action: $action  # some special field values are possible, check the wiki
+  OS: os_distribution os_distribution_version  # you can combine multiple values with a space between
+# Much like you can set a variable lookup order for inventory fields
+inventory_list_vars: hostname | name | ip
 # Optionally set a limit for the number of threads Broker can use for actions
 thread_limit: None
 # Host SSH Settings

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,5 +1,7 @@
 # Broker settings
 _version: 0.6.0
+# Disable rich colors
+less_colors: False
 # different log levels for file and stdout
 logging:
     console_level: info


### PR DESCRIPTION
With the changes we've been making in 0.6 toward a better, more customizable and visually appealing, user experience. It's time that we revisited the inventory command.
The --curated view introduced in 0.5.x has now become the default inventory view. The original default view is now present in its new form and home with the --list flag.
The --details flag largely retains the functionality it did before. However, it involves much less processing than before.

One important piece added in this is the ability to customize the inventory fields on a per-user basis. The details on this customization are documented in detail in the supporting code.
It will also be important to document this in the wiki upon release.

Here's a screenshot of what the new changes look like (with the details view cut-off for security).
![Screenshot from 2024-10-07 16-26-56](https://github.com/user-attachments/assets/93677c13-c622-4070-b26f-50ea8b6b6565)
