### PR TITLE
Remove deprecated method for pulling AnsibleTower host facts

### DIFF
--- a/tests/data/ansible_tower/fake_jobs.json
+++ b/tests/data/ansible_tower/fake_jobs.json
@@ -33,18 +33,24 @@
         "name": "deploy-set-stats-for-jenkins",
         "artifacts": {
             "provider": "rhv",
-            "reported_devices": {
-                "nics": [
-                    "lo",
-                    "eth0"
-                ]
+            "_broker_args": {
+                "host_type": "host"
             },
-            "host_type": "host",
-            "os_distribution_version": "7.8",
-            "fqdn": "fake.host.test.com",
-            "template": "",
-            "os_distribution": "RedHat",
-            "name": "fake-physical-host"
+            "_broker_facts": {
+                "fqdn": "fake.host.test.com",
+                "name": [
+                    "fake-physical-host"
+                ],
+                "os_distribution": "RedHat",
+                "os_distribution_version": "9.4",
+                "reported_devices": {
+                    "nics": [
+                        "lo",
+                        "eth0"
+                    ]
+                },
+                "template": ""
+            }
         }
     }
 ]

--- a/tests/providers/test_ansible_tower.py
+++ b/tests/providers/test_ansible_tower.py
@@ -98,7 +98,7 @@ def test_host_creation(tower_stub):
     host = tower_stub.construct_host(job, bx.host_classes)
     assert isinstance(host, bx.host_classes["host"])
     assert host.hostname == "fake.host.test.com"
-    assert host._broker_args["os_distribution_version"] == "7.8"
+    assert host.os_distribution_version == "9.4"
 
 
 def test_workflow_lookup_failure(tower_stub):


### PR DESCRIPTION
This PR:
- removes the old method of pulling host data from AAP, which is no longer used since https://github.com/SatelliteQE/broker/pull/261
- updates the test data for the mock workflow job, to reflect the newer method
