### PR TITLE
Improve container provider syncs

### DIFF
--- a/broker/providers/container.py
+++ b/broker/providers/container.py
@@ -17,8 +17,10 @@ from broker.settings import settings
 
 def container_info(container_inst):
     """Return a dict of container information."""
+    attr_dict = {"container_host": "Image", "_broker_origin": "Labels/broker.origin"}
     info = {
         "_broker_provider": "Container",
+        "_broker_args": helpers.dict_from_paths(container_inst.attrs, attr_dict),
         "name": container_inst.name,
         "hostname": container_inst.id[:12],
         "image": container_inst.image.tags,


### PR DESCRIPTION
When a user syncs a Container provider with at least one container that is missing from their local inventory, it breaks their local executions of `broker inventory`.

With this change, we reconstruct the "_broker_args" with what limited information is available from the synced container instance.