### PR TITLE
Fix for ruamel interactions with awxkit objects

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -10,7 +10,7 @@ from dynaconf import Validator
 from logzero import logger
 
 from broker import exceptions
-from broker.helpers import eval_filter, find_origin
+from broker.helpers import eval_filter, find_origin, yaml
 from broker.settings import settings
 
 try:
@@ -20,6 +20,12 @@ except ImportError as err:
 
 from broker import helpers
 from broker.providers import Provider
+
+# ruamel has a hard time with PseudoNamespace objects
+yaml.representer.add_representer(
+    awxkit.utils.PseudoNamespace,
+    lambda dumper, data: dumper.represent_dict(dict(data)),
+)
 
 
 def convert_pseudonamespaces(attr_dict):


### PR DESCRIPTION
Cole encountered an issue where inventory syncs were failing because ruamel wasn't able to handle awxkit's Psuedonamespace objects. This simply adds a new representer for them, fixing the issue.