### PR TITLE
Fix issue around host garbage collection

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -74,8 +74,8 @@ class Host:
 
     def __del__(self):
         """Try to close the connection on garbage collection of the host instance."""
-        self.close()
-        # object.__del__ DNE, so I don't have to call it here.
+        if hasattr(self, "_session") and self._session is not None:
+            self.close()
         # If host inherits from a different class with __del__, it should get called through super
 
     @property


### PR DESCRIPTION
As identified in #334, we can get into a state during garbage collection where a Host instance's _session attribute is missing. However, the del method calls close, which expects that attribute to be in place.
In this change, we add a couple of conditions to the del to gate the close call.

fixes #334