### PR TITLE
Handle decodes when stdout or stderr is None

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -640,8 +640,8 @@ class Result:
             status, (stdout, stderr) = duplex_exec
             return cls(
                 status=status,
-                stdout=stdout.decode("utf-8"),
-                stderr=stderr.decode("utf-8"),
+                stdout=stdout.decode("utf-8") if stdout else "",
+                stderr=stderr.decode("utf-8") if stderr else "",
             )
 
         if duplex_exec.output[0]:

--- a/tests/functional/test_containers.py
+++ b/tests/functional/test_containers.py
@@ -5,7 +5,6 @@ from click.testing import CliRunner
 from broker import Broker
 from broker.commands import cli
 from broker.providers.container import Container
-from broker.settings import inventory_path
 from broker.settings import settings_path as SETTINGS_PATH
 
 SCENARIO_DIR = Path("tests/data/cli_scenarios/containers")
@@ -135,3 +134,9 @@ def test_broker_multi_manager():
             multi_hosts["ubi8"][1].execute("hostname").stdout.strip()
             == multi_hosts["ubi8"][1].hostname
         )
+
+
+def test_custom_hostname():
+    with Broker(container_host="ubi8:latest", hostname="my.custom.hostname") as chost:
+        assert chost.hostname == "my.custom.hostname"
+        assert chost.execute("hostname").strip() == "my.custom.hostname"


### PR DESCRIPTION
Looks like a recent change has allowed these values to potentially be None. In this case, we shouldn't try to decode and just return an empty string.

Also included a functional test that didn't make it into the previous commit adding the hostname change.