### PR TITLE
Remove hosts from local inventory by (unique) name instead of hostname during checkin

### DIFF
--- a/broker/broker.py
+++ b/broker/broker.py
@@ -215,7 +215,7 @@ class Broker:
                 _host = completed.result()
                 self._hosts = [h for h in self._hosts if h.to_dict() != _host.to_dict()]
                 logger.debug(f"Completed checkin process for {_host.hostname or _host.name}")
-        helpers.update_inventory(remove=[h.hostname for h in hosts])
+        helpers.update_inventory(remove=[h.name for h in hosts])
 
     def _extend(self, host):
         """Extend a single VM."""


### PR DESCRIPTION
In some cases, the `hostname` attribute is not set or available on AAP hosts. For example:

```
Id | Hostname              | Name
0  | Unknown               | tpapaioa-AAP-MR1
1  | Unknown               | tpapaioa-AAP-MR2
2  | host1.example.com     | tpapaioa-rhel-9.5-3
```

If I check in one of these hosts, then broker removes all of them from `inventory.yaml`, instead of just the one that was removed from AAP:

```
$ broker checkin 0
[....]
$ broker inventory
Id | Hostname              | Name
0  | host1.example.com     | tpapaioa-rhel-9.5-3
```

This PR updates `Broker.checkin()` to pass the host's unique `name` attribute instead, so that only the given hosts are removed from the inventory.