### PR TITLE
Update timeout logic to better handle "falsey" values

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -121,7 +121,7 @@ class Host:
 
         username = username or self.username
         password = password or self.password
-        timeout = timeout or self.timeout
+        timeout = self.timeout if timeout is None else timeout
         _hostname = self.hostname
         _port = self.port or port
         ipv6 = ipv6 or self.ipv6
@@ -169,7 +169,7 @@ class Host:
         Returns:
             str: The output of the command executed on the host.
         """
-        timeout = timeout or self.default_timeout
+        timeout = self.default_timeout if timeout is None else timeout
         logger.debug(f"{self.hostname} executing command: {command}")
         res = self.session.run(command, timeout=timeout)
         logger.debug(f"{self.hostname} command result:\n{res}")


### PR DESCRIPTION
If a user sets a default timeout on the host class, but wants to pass a timeout of 0 to a command, it will currently use the default since the check relies on "falsey" values.
In this change, we're just going to be more specific with the conditional check.