### PR TITLE
Add resilience to the resilient_job_wait for AnsibleTower

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -50,7 +50,7 @@ def resilient_job_wait(job, timeout=None):
         try:
             job.wait_until_completed(timeout=timeout)
             completed = True
-        except ConnectionError as err:
+        except (ConnectionError, awxkit.exceptions.Unknown) as err:
             logger.error(f"Error occurred while waiting for job: {err}")
             logger.info("Retrying job wait...")
 


### PR DESCRIPTION
We're now seeing a more specific "unknown" exception from awxkit instead of just the ConnectionErrors we're seen in the past. Adding in that exception to what we're ignoring.