### PR TITLE
Changes needed for AAP 2.5 compatibility

### DIFF
--- a/broker/config_migrations/v0_6_9.py
+++ b/broker/config_migrations/v0_6_9.py
@@ -1,0 +1,23 @@
+"""Config migrations for versions older than 0.6.9 to 0.6.9."""
+
+from logzero import logger
+
+TO_VERSION = "0.6.9"
+
+
+def add_aap_version_setting(config_dict):
+    """Add the AAP_VERSION setting to AnsibleTower provider."""
+    logger.debug("Adding aap_version setting to AnsibleTower provider.")
+    ansible_tower = config_dict.get("AnsibleTower", {})
+    if "aap_version" not in ansible_tower:
+        ansible_tower["aap_version"] = None
+    config_dict["AnsibleTower"] = ansible_tower
+    return config_dict
+
+
+def run_migrations(config_dict):
+    """Run all migrations."""
+    logger.info(f"Running config migrations for {TO_VERSION}.")
+    config_dict = add_aap_version_setting(config_dict)
+    config_dict["_version"] = TO_VERSION
+    return config_dict

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -226,7 +226,9 @@ def load_inventory(filter=None):
     :return: list of dictionaries
     """
     inv_data = load_file(settings.inventory_path, warn=False)
-    return inv_data if not filter else eval_filter(inv_data, filter)
+    if inv_data and filter:
+        inv_data = eval_filter(inv_data, filter)
+    return inv_data or []
 
 
 def update_inventory(add=None, remove=None):

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -695,7 +695,8 @@ class AnsibleTower(Provider):
         job_api_url = url_parser.urljoin(self.url, str(job.url))
         # Need to change the url subject for job templates. If this increases, then come up with a better solution
         job_ui_url = url_parser.urljoin(
-            self.url, f"/{AAP_URL_PREFIX}/jobs/{'playbook' if subject == 'job_template' else subject}/{job_number}/output"
+            self.url,
+            f"/{AAP_URL_PREFIX}/jobs/{'playbook' if subject == 'job_template' else subject}/{job_number}/output",
         )
         helpers.emit(api_url=job_api_url, ui_url=job_ui_url)
         logger.info(f"Waiting for job: \nAPI: {job_api_url}\nUI: {job_ui_url}")

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,5 +1,5 @@
 # Broker settings
-_version: 0.6.0
+_version: 0.6.9
 # Disable rich colors
 less_colors: False
 # different log levels for file and stdout
@@ -33,6 +33,7 @@ ssh:
 # Provider settings
 AnsibleTower:
     base_url: "https://<ansible tower host>/"
+    aap_version: null
     # Username is required for both token and password-based authentication
     username: "<username>"
     # token is the preferred authentication method


### PR DESCRIPTION
This change makes it possible for users to interact with AAP 2.5+ without having to set the awxkit environment variable themselves.

This path currently is a bit heavy-handed, but may be simplified in the future.