### PR TITLE
Proper payload serialization for awxkit

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -700,7 +700,7 @@ class AnsibleTower(Provider):
         kwargs["_broker_extra_vars"] = {
             k: v for k, v in kwargs.items() if k not in workflow_extra_vars
         }
-        payload["extra_vars"] = str(kwargs)
+        payload["extra_vars"] = json.dumps(kwargs)
         logger.debug(
             f"Launching {subject}: {url_parser.urljoin(self.url, str(target.url))}\n{payload=}"
         )


### PR DESCRIPTION
# Use JSON serialization for extra_vars payload

This PR fixes #372 - an issue with serialization of Enum values in kwargs passed to awxkit (AWX/AAP).

## Problem
Currently, when passing Enum objects (like NetworkType) in kwargs to AWX's execute method, the code uses `str(kwargs)` which produces a string representation that includes Python object references rather than their actual values. This causes improper serialization and interpretation on the AWX side.

## Solution
Replace `str(kwargs)` with `json.dumps(kwargs)` to properly serialize the kwargs dictionary, ensuring Enum values are converted to their string representations and the entire structure is converted to valid JSON.

## Benefits
- Ensures consistent serialization of all objects passed to AWX/AAP
- Prevents cryptic errors when using structured data in workflows
- More maintainable and standard approach to API data serialization

## Testing
Tested with NetworkType enum objects from robottelo framework to ensure they are properly serialized before being sent to AWX/AAP.
