### PR TITLE
Raise an error when an unknown nick is used.

### DIFF
--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -176,6 +176,8 @@ def resolve_nick(nick):
     nick_names = settings.settings.get("NICKS") or {}
     if nick in nick_names:
         return settings.settings.NICKS[nick].to_dict()
+    else:
+        raise exceptions.UserError(f"Unknown nick: {nick}")
 
 
 def load_file(file, warn=True):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -172,3 +172,9 @@ def test_kwargs_from_click_ctx():
 
     kwargs = helpers.kwargs_from_click_ctx(ctx)
     assert kwargs == {"arg1": "value1", "arg2": "value2"}
+
+
+def test_resolve_nick_raises_error_for_unknown_nick():
+    """Test that resolve_nick raises UserError for a non-existent nick."""
+    with pytest.raises(exceptions.UserError, match=r"Unknown nick: nothere"):
+        helpers.resolve_nick("nothere")


### PR DESCRIPTION
Simply raise a user error when the nick can't be found.

fixes #376