### PR TITLE
Switch build backend to uv_build

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,17 +25,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Setup and Build
+      - name: Build package
         env:
           UV_SYSTEM_PYTHON: 1
         run: |
-          uv pip install --system "broker[setup] @ ."
-          python -m build
-          python -m twine check dist/*
+          uv build
 
-      - name: Build and publish
-        uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip_existing: true
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          uv publish

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,5 +1,5 @@
 # Broker settings
-_version: 0.6.9
+_version: 0.7.0
 # Disable rich colors
 less_colors: False
 # different log levels for file and stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm[toml]", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
 
 [project]
 name = "broker"
+version = "0.7.0"
 description = "The infrastructure middleman."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -32,19 +33,23 @@ dependencies = [
     "setuptools",
     "ssh2-python",
 ]
-dynamic = [
-    "version",
-] # dynamic fields to update on build - version via setuptools_scm
 
 [project.urls]
 Repository = "https://github.com/SatelliteQE/broker"
 
 [project.optional-dependencies]
 beaker = ["beaker-client"]
-dev = ["docker", "pexpect", "pre-commit", "pytest", "pytest-randomly", "ruff"]
+dev = [
+    "docker",
+    "pexpect",
+    "pre-commit",
+    "pytest",
+    "pytest-randomly",
+    "ruff",
+    "bumpver",
+]
 docker = ["docker", "paramiko"]
 podman = ["podman>=5.2"]
-setup = ["build", "twine"]
 
 ssh2_python = ["ssh2-python"]
 ansible_pylibssh = ["ansible-pylibssh"]
@@ -54,15 +59,23 @@ paramiko = ["paramiko"]
 [project.scripts]
 broker = "broker.commands:cli"
 
-[tool.setuptools]
-platforms = ["any"]
-zip-safe = false
-include-package-data = true
+[tool.uv.build-backend]
+module-root = ""
 
-[tool.setuptools.packages.find]
-include = ["broker"]
+[tool.bumpver]
+current_version = "0.7.0"
+version_pattern = "MAJOR.MINOR.PATCH"
+commit_message = "bump version to {new_version}"
+tag_message = "{new_version}"
+tag_scope = "default"
+commit = true
+tag = true
+push = false
 
-[tool.setuptools_scm] # same as use_scm_version=True in setup.py
+[tool.bumpver.file_patterns]
+"pyproject.toml" = ['^version = "{version}"', '^current_version = "{version}"']
+"broker_settings.yaml.example" = ["^_version: {version}"]
+
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
This change swaps our build backend from setuptools to uv_build. A downside of this is that we lose scm-based versioning. To accomodate for that, I've also added a helper script that should be ran to bump the version befoe tagging.

Also switching to uv publish while we're a it.