### PR TITLE
Add max wait time and 403 retry to Ansible Tower job wait

### DIFF
--- a/broker/config_migrations/v0_6_12.py
+++ b/broker/config_migrations/v0_6_12.py
@@ -1,0 +1,23 @@
+"""Config migrations for versions older than 0.6.12 to 0.6.12."""
+
+from logzero import logger
+
+TO_VERSION = "0.6.12"
+
+
+def add_max_resilient_wait_setting(config_dict):
+    """Add the max_resilient_wait setting to AnsibleTower provider."""
+    logger.debug("Adding max_resilient_wait setting to AnsibleTower provider.")
+    ansible_tower = config_dict.get("AnsibleTower", {})
+    if "max_resilient_wait" not in ansible_tower:
+        ansible_tower["max_resilient_wait"] = 7200  # 2 hours default
+    config_dict["AnsibleTower"] = ansible_tower
+    return config_dict
+
+
+def run_migrations(config_dict):
+    """Run all migrations."""
+    logger.info(f"Running config migrations for {TO_VERSION}.")
+    config_dict = add_max_resilient_wait_setting(config_dict)
+    config_dict["_version"] = TO_VERSION
+    return config_dict

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -1,5 +1,5 @@
 # Broker settings
-_version: 0.6.9
+_version: 0.6.12
 # Disable rich colors
 less_colors: False
 # different log levels for file and stdout
@@ -44,6 +44,7 @@ AnsibleTower:
     extend_workflow: "extend-vm"
     new_expire_time: "+172800"
     workflow_timeout: 3600
+    max_resilient_wait: 7200
     results_limit: 50
 Container:
     instances:


### PR DESCRIPTION
Features:
- Introduce `max_wait` parameter to `resilient_job_wait` to set a maximum duration for retries, preventing infinite waits.
- Allow `resilient_job_wait` to retry on `awxkit.exceptions.Forbidden` (HTTP 403) errors, improving resilience.

Refactoring:
- Add a 5-second delay before retrying in `resilient_job_wait` to reduce API hammering during transient errors.

Configuration:
- Add `ANSIBLETOWER.max_resilient_wait` setting, defaulting to 7200 seconds (2 hours), to control the maximum retry duration.
- Update `broker_settings.yaml.example` with the new `max_resilient_wait` setting.