### PR TITLE
Implement flavor retrieval and refine provider help display

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -124,17 +124,17 @@ def populate_providers(click_group):
             broker_inst.provider_help(ctx.info_name)
 
         # iterate through available actions and populate options from them
-        for option, (p_cls, is_flag) in PROVIDER_HELP.items():
+        for option, (p_cls, is_flag, alt_text) in PROVIDER_HELP.items():
             if p_cls is not prov_class:
                 continue
             option = option.replace("_", "-")  # noqa: PLW2901
             if is_flag:
                 provider_cmd = click.option(
-                    f"--{option}", is_flag=True, help=f"Get available {option}"
+                    f"--{option}", is_flag=True, help=alt_text or f"Get available {option}"
                 )(provider_cmd)
             else:
                 provider_cmd = click.option(
-                    f"--{option}", type=str, help=f"Get information about a {option}"
+                    f"--{option}", type=str, help=alt_text or f"Get information about a {option}"
                 )(provider_cmd)
         provider_cmd = click.option(
             "--results-limit",

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -737,7 +737,7 @@ def temporary_tar(paths):
     temp_tar.unlink()
 
 
-def dictlist_to_table(dict_list, title=None, _id=False):
+def dictlist_to_table(dict_list, title=None, _id=False, headers=False):
     """Convert a list of dictionaries to a rich table."""
     # I like pretty colors, so let's cycle through them
     column_colors = ["cyan", "magenta", "green", "yellow", "blue", "red"]
@@ -757,4 +757,23 @@ def dictlist_to_table(dict_list, title=None, _id=False):
         row = [str(id_num)] if _id else []
         row.extend([str(value) for value in data_dict.values()])
         table.add_row(*row)
+    if not headers:
+        table.show_header = False
+    return table
+
+
+def dict_to_table(in_dict, title=None, headers=None):
+    """Convert a dictionary into a rich table."""
+    # need to normalize the values first
+    in_dict = {k: str(v) for k, v in in_dict.items()}
+    table = Table(title=title)
+    if isinstance(headers, tuple | list):
+        table.add_column(headers[0], style="cyan")
+        table.add_column(headers[1], style="magenta")
+    else:
+        table.add_column("key", style="cyan")
+        table.add_column("value", style="magenta")
+        table.show_header = False
+    for key, val in in_dict.items():
+        table.add_row(key, val)
     return table

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -72,6 +72,7 @@ class ProviderMeta(ABCMeta):
                             PROVIDER_HELP[_name] = (
                                 new_cls,
                                 isinstance(param.default, bool),
+                                getattr(obj, "_help_overrides", {}).get(_name),
                             )
                             logger.debug(f"Registered help option {_name} for provider {_name}")
                 elif hasattr(obj, "_as_action"):
@@ -207,3 +208,13 @@ class Provider(metaclass=ProviderMeta):
             return func
 
         return decorator
+
+    @staticmethod
+    def help_override(**overrides):
+        """Decorate the provider_help function to overwrite auto-generated help text."""
+
+        def wrapper(func):
+            func._help_overrides = overrides
+            return func
+
+        return wrapper

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -14,6 +14,7 @@ from dynaconf import Validator
 from logzero import logger
 from packaging.version import InvalidVersion, Version
 from requests.exceptions import ConnectionError
+from rich.console import Console
 
 from broker import exceptions
 from broker.helpers import MockStub, eval_filter, find_origin, yaml
@@ -802,6 +803,7 @@ class AnsibleTower(Provider):
             provider_labels=provider_labels,
         )
 
+    @Provider.help_override(tower_inventory="Filter results by the specified inventory.")
     def provider_help(  # noqa: PLR0911, PLR0912, PLR0915 - Possible TODO refactor
         self,
         workflows=False,
@@ -811,10 +813,15 @@ class AnsibleTower(Provider):
         templates=False,
         inventories=False,
         inventory=None,
+        flavors=False,
+        tower_inventory=None,
         **kwargs,
     ):
         """Get a list of extra vars and their defaults from a workflow."""
         results_limit = kwargs.get("results_limit", self._settings.ANSIBLETOWER.results_limit)
+        rich_console = Console(no_color=self._settings.less_colors)
+        # if a user passes a different tower inventory, let's try using that
+        self._inventory = tower_inventory
         if workflow:
             if wfjt := self._v2.workflow_job_templates.get(name=workflow).results:
                 wfjt = wfjt.pop()
@@ -822,11 +829,17 @@ class AnsibleTower(Provider):
                 logger.warning(f"Workflow {workflow} not found!")
                 return
             default_inv = self._v2.inventory.get(id=wfjt.inventory).results.pop()
-            logger.info(
-                f"\nDescription:\n{wfjt.description}\n\n"
-                f"Accepted additional nick fields:\n{helpers.yaml_format(wfjt.extra_vars)}"
-                f"tower_inventory: {default_inv['name']}"
+            top_table = helpers.dict_to_table(
+                {"Description": wfjt.description, "Inventory": default_inv["name"]},
+                title=f"{workflow} information",
             )
+            rich_console.print(top_table)
+            extras_table = helpers.dict_to_table(
+                json.loads(wfjt.extra_vars),
+                title="Workflow Variables",
+                headers=("Variable", "Default Value"),
+            )
+            rich_console.print(extras_table)
         elif workflows:
             workflows = [
                 workflow.name
@@ -839,16 +852,24 @@ class AnsibleTower(Provider):
             if res_filter := kwargs.get("results_filter"):
                 workflows = eval_filter(workflows, res_filter, "res")
                 workflows = workflows if isinstance(workflows, list) else [workflows]
-            workflows = "\n".join(workflows[:results_limit])
-            logger.info(f"Available workflows:\n{workflows}")
+            workflow_table = helpers.dictlist_to_table(
+                [{"name": workflow} for workflow in workflows[:results_limit]],
+                title="Available Workflows",
+                _id=False,
+                headers=False,
+            )
+            rich_console.print(workflow_table)
         elif inventory:
             if inv := self._v2.inventory.get(name=inventory, kind="").results:
                 inv = inv.pop()
             else:
                 logger.warning(f"Inventory {inventory} not found!")
                 return
-            inv = {"Name": inv.name, "ID": inv.id, "Description": inv.description}
-            logger.info(f"Accepted additional nick fields:\n{helpers.yaml_format(inv)}")
+            inv_table = helpers.dict_to_table(
+                {"ID": inv.id, "Name": inv.name, "Description": inv.description},
+                title="Inventory Details",
+            )
+            rich_console.print(inv_table)
         elif inventories:
             inv = [inv.name for inv in self._v2.inventory.get(kind="", page_size=1000).results]
             if not inv:
@@ -857,8 +878,13 @@ class AnsibleTower(Provider):
             if res_filter := kwargs.get("results_filter"):
                 inv = eval_filter(inv, res_filter, "res")
                 inv = inv if isinstance(inv, list) else [inv]
-            inv = "\n".join(inv[:results_limit])
-            logger.info(f"Available Inventories:\n{inv}")
+            inv_table = helpers.dictlist_to_table(
+                [{"name": i} for i in inv[:results_limit]],
+                title="Available Inventories",
+                _id=False,
+                headers=False,
+            )
+            rich_console.print(inv_table)
         elif job_template:
             if jt := self._v2.job_templates.get(name=job_template).results:
                 jt = jt.pop()
@@ -866,11 +892,17 @@ class AnsibleTower(Provider):
                 logger.warning(f"Job Template {job_template} not found!")
                 return
             default_inv = self._v2.inventory.get(id=jt.inventory).results.pop()
-            logger.info(
-                f"\nDescription:\n{jt.description}\n\n"
-                f"Accepted additional nick fields:\n{helpers.yaml_format(jt.extra_vars)}"
-                f"tower_inventory: {default_inv['name']}"
+            top_table = helpers.dict_to_table(
+                {"Description": jt.description, "Inventory": default_inv["name"]},
+                title=f"{job_template} information",
             )
+            rich_console.print(top_table)
+            extras_table = helpers.dict_to_table(
+                json.loads(jt.extra_vars),
+                title="Job Template Variables",
+                headers=("Variable", "Default Value"),
+            )
+            rich_console.print(extras_table)
         elif job_templates:
             job_templates = [
                 job_template.name
@@ -885,8 +917,13 @@ class AnsibleTower(Provider):
                 job_templates = (
                     job_templates if isinstance(job_templates, list) else [job_templates]
                 )
-            job_templates = "\n".join(job_templates[:results_limit])
-            logger.info(f"Available job templates:\n{job_templates}")
+            job_template_table = helpers.dictlist_to_table(
+                [{"name": job_template} for job_template in job_templates[:results_limit]],
+                title="Available Job Templates",
+                _id=False,
+                headers=False,
+            )
+            rich_console.print(job_template_table)
         elif templates:
             templates = list(
                 set(
@@ -902,8 +939,27 @@ class AnsibleTower(Provider):
             if res_filter := kwargs.get("results_filter"):
                 templates = eval_filter(templates, res_filter, "res")
                 templates = templates if isinstance(templates, list) else [templates]
-            templates = "\n".join(templates[:results_limit])
-            logger.info(f"Available templates:\n{templates}")
+            template_table = helpers.dictlist_to_table(
+                [{"name": template} for template in templates[:results_limit]],
+                title="Available Templates",
+                _id=False,
+                headers=False,
+            )
+            rich_console.print(template_table)
+        elif flavors:
+            flavors = self.execute(workflow="list-flavors", artifacts="last")["data_out"][
+                "list_flavors"
+            ]
+            if not flavors:
+                logger.warning("No flavors found!")
+                return
+            if res_filter := kwargs.get("results_filter"):
+                flavors = eval_filter(flavors, res_filter, "res")
+                flavors = flavors if isinstance(flavors, list) else [flavors]
+            flavor_table = helpers.dictlist_to_table(
+                flavors[:results_limit], title="Available Flavors", _id=False
+            )
+            rich_console.print(flavor_table)
 
     def release(self, name, broker_args=None):
         """Release the host back to the tower instance via the release workflow."""


### PR DESCRIPTION
Features:
- Add `flavors` option to `ansible-tower provider help` command to list available deployment flavors.
- Introduce `Provider.help_override` decorator, enabling providers to define custom help text for their CLI options, leading to more descriptive usage information.

Refactoring:
- Improve output styling for `ansible-tower provider help` commands (e.g., `workflows`, `inventory`, `templates`) by leveraging `rich` tables for enhanced readability and structured presentation.
- Add new helper function `dict_to_table` to convert dictionaries into formatted `rich` tables.
- Enhance `dictlist_to_table` helper to support optional display of table headers, providing more control over output presentation.
- Update provider meta-class to integrate custom help text defined via `_help_overrides` into CLI option generation.

Misc:
- Add `GEMINI.md` to establish guidelines for interacting with the `broker` project using Gemini, covering project overview, structure, development conventions, and AI-specific interaction rules.

Fixes: #396 