### PR TITLE
Defer imports for optional provider dependencies

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           UV_SYSTEM_PYTHON: 1
         run: |
-          uv pip install "broker[dev,podman,openstack] @ ."
+          uv pip install "broker[ansibletower,dev,podman,openstack] @ ."
           broker config init --from tests/data/broker_settings.yaml
           broker config view
           pytest -v tests/ --ignore tests/functional --ignore tests/test_ssh.py

--- a/broker/logger.py
+++ b/broker/logger.py
@@ -4,7 +4,6 @@ import copy
 from enum import IntEnum
 import logging
 
-import awxkit
 import logzero
 import urllib3
 
@@ -60,8 +59,13 @@ logging.addLevelName("TRACE", LOG_LEVEL.TRACE)
 logzero.DEFAULT_COLORS[LOG_LEVEL.TRACE.value] = logzero.colors.Fore.MAGENTA
 
 
-def patch_awx_for_verbosity(api):
+def try_patch_awx_for_verbosity():
     """Patch the awxkit API to enable trace-level logging of API calls to Ansible provider."""
+    try:
+        from awxkit import api
+    except ImportError:
+        logzero.logger.debug("awxkit not installed, skipping awxkit logging patch")
+        return
     awx_log = api.client.log
     awx_log.parent = logzero.logger
 
@@ -155,5 +159,5 @@ def setup_logzero(
 
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-patch_awx_for_verbosity(awxkit.api)
+try_patch_awx_for_verbosity()
 setup_logzero()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,20 +21,20 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "awxkit",
     "click",
     "dynaconf>=3.1.6,<4.0.0",
     "logzero",
     "packaging",
     "rich",
     "rich_click",
-    "ruamel.yaml"
+    "ruamel.yaml",
 ]
 
 [project.urls]
 Repository = "https://github.com/SatelliteQE/broker"
 
 [project.optional-dependencies]
+ansibletower = ["awxkit"]
 beaker = ["beaker-client"]
 dev = [
     "docker",

--- a/tests/data/cli_scenarios/satlab/checkout_rhel91.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_rhel91.yaml
@@ -1,2 +1,0 @@
-workflow: deploy-rhel
-deploy_rhel_version: "9.1"

--- a/tests/data/cli_scenarios/satlab/checkout_rhel96.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_rhel96.yaml
@@ -1,0 +1,2 @@
+workflow: deploy-rhel
+deploy_rhel_version: "9.6"

--- a/tests/data/cli_scenarios/satlab/checkout_sat_618.yaml
+++ b/tests/data/cli_scenarios/satlab/checkout_sat_618.yaml
@@ -1,2 +1,2 @@
 workflow: deploy-satellite
-deploy_sat_version: "6.13"
+deploy_sat_version: "6.18"

--- a/tests/functional/test_satlab.py
+++ b/tests/functional/test_satlab.py
@@ -25,6 +25,8 @@ def skip_if_not_configured():
 @pytest.fixture(scope="module")
 def temp_inventory():
     """Temporarily move the local inventory, then move it back when done"""
+    if not inventory_path.exists():
+        inventory_path.write_text("[]")
     backup_path = inventory_path.rename(f"{inventory_path.absolute()}.bak")
     yield
     CliRunner().invoke(cli, ["checkin", "--all", "--filter", "_broker_provider<AnsibleTower"])


### PR DESCRIPTION
Refactoring:
- Moved `awxkit` and `openstacksdk` imports from module-level to class `__init__` methods for `AnsibleTower` and `OpenStack` providers.
- This ensures these dependencies are only imported when an instance of their respective provider class is created, making the base `broker` package lighter.
- The `ruamel.yaml` representer configuration for `awxkit.utils.PseudoNamespace` is now applied only when `awxkit` is imported, including during re-configuration for AAP 2.5+.
- Improved `ImportError` messages to guide users on installing specific optional dependency sets (e.g., `broker[ansibletower]`).

Configuration:
- Moved `awxkit` from the main `dependencies` list to `ansibletower` under `[project.optional-dependencies]` in `pyproject.toml`.
- This correctly categorizes `awxkit` as an optional dependency.