### PR TITLE
Prepare 0.7.0rc2 release with installability and display fixes

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -124,7 +124,7 @@ def populate_providers(click_group):
             broker_inst.provider_help(ctx.info_name)
 
         # iterate through available actions and populate options from them
-        for option, (p_cls, is_flag, alt_text) in PROVIDER_HELP.items():
+        for option, p_cls, is_flag, alt_text in PROVIDER_HELP:
             if p_cls is not prov_class:
                 continue
             option = option.replace("_", "-")  # noqa: PLW2901

--- a/broker/helpers.py
+++ b/broker/helpers.py
@@ -743,7 +743,7 @@ def temporary_tar(paths):
     temp_tar.unlink()
 
 
-def dictlist_to_table(dict_list, title=None, _id=False, headers=False):
+def dictlist_to_table(dict_list, title=None, _id=False, headers=True):
     """Convert a list of dictionaries to a rich table."""
     # I like pretty colors, so let's cycle through them
     column_colors = ["cyan", "magenta", "green", "yellow", "blue", "red"]

--- a/broker/providers/__init__.py
+++ b/broker/providers/__init__.py
@@ -51,7 +51,7 @@ PROVIDERS = {}
 # action: (InterfaceClass, "method_name")
 PROVIDER_ACTIONS = {}
 # action: (InterfaceClass, "method_name")
-PROVIDER_HELP = {}
+PROVIDER_HELP = []
 
 
 class ProviderMeta(ABCMeta):
@@ -68,13 +68,16 @@ class ProviderMeta(ABCMeta):
                     # register the help options based on the function arguments
                     for _name, param in inspect.signature(obj).parameters.items():
                         if _name not in ("self", "kwargs", "broker_settings"):
-                            # {_name: (cls, is_flag)}
-                            PROVIDER_HELP[_name] = (
-                                new_cls,
-                                isinstance(param.default, bool),
-                                getattr(obj, "_help_overrides", {}).get(_name),
+                            # (name, prov_cls, is_flag, help_override)
+                            PROVIDER_HELP.append(
+                                (
+                                    _name,
+                                    new_cls,
+                                    isinstance(param.default, bool),
+                                    getattr(obj, "_help_overrides", {}).get(_name),
+                                )
                             )
-                            logger.debug(f"Registered help option {_name} for provider {_name}")
+                            logger.debug(f"Registered help option {_name} for provider {name}")
                 elif hasattr(obj, "_as_action"):
                     for action in obj._as_action:
                         PROVIDER_ACTIONS[action] = (new_cls, attr)

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -216,7 +216,7 @@ def get_awxkit_and_uname(
     # Now proceed with token authentication (either provided or newly created)
     if token:
         helpers.emit(auth_type="token")
-        logger.info("Using token authentication")
+        logger.debug("Using token authentication")
         awxkit_config.token = token
         try:
             root.connection.login(username=None, password=None, token=token, auth_type="Bearer")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "broker"
-version = "0.7.0rc1"
+version = "0.7.0rc2"
 description = "The infrastructure middleman."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,6 +25,7 @@ dependencies = [
     "dynaconf>=3.1.6,<4.0.0",
     "logzero",
     "packaging",
+    "requests",
     "rich",
     "rich_click",
     "ruamel.yaml",


### PR DESCRIPTION
Configuration:
- Bump version to `0.7.0rc2`.
- Add `requests` package as a core dependency to ensure smooth installations and handle `urllib3` requirements.

Fixes:
- Ensure provider help options are correctly registered and iterated by changing `PROVIDER_HELP` to a list of tuples. This resolves an issue where options might not have been correctly discovered.
- Default `dictlist_to_table` to include headers for improved readability of command output.
- Wrap `urllib3` warning disabling in a `try` block to prevent `ImportError` if `urllib3` is not present, enhancing installability robustness.

Refactoring:
- Adjust log level for token authentication messages from `info` to `debug` for clearer logging output.