### PR TITLE
Refactor Paramiko bind and update SSH backend configuration

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -91,7 +91,7 @@ jobs:
         if: steps.changed_common_ssh_files.outputs.any_changed == 'true' || steps.changed_hussh_files.outputs.any_changed == 'true'
         env:
           UV_SYSTEM_PYTHON: 1
-          BROKER_SSH_BACKEND: hussh
+          BROKER_SSH__BACKEND: hussh
         run: |
           uv pip install "broker[hussh] @ ."
           pytest -v tests/test_ssh.py
@@ -100,7 +100,7 @@ jobs:
         if: steps.changed_common_ssh_files.outputs.any_changed == 'true' || steps.changed_paramiko_files.outputs.any_changed == 'true'
         env:
           UV_SYSTEM_PYTHON: 1
-          BROKER_SSH_BACKEND: paramiko
+          BROKER_SSH__BACKEND: paramiko
         run: |
           uv pip install "broker[paramiko] @ ."
           pytest -v tests/test_ssh.py
@@ -109,7 +109,7 @@ jobs:
         if: steps.changed_common_ssh_files.outputs.any_changed == 'true' || steps.changed_ssh2_files.outputs.any_changed == 'true'
         env:
           UV_SYSTEM_PYTHON: 1
-          BROKER_SSH_BACKEND: ssh2-python
+          BROKER_SSH__BACKEND: ssh2-python
         run: |
           uv pip install "broker[ssh2-python] @ ."
           pytest -v tests/test_ssh.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,13 @@ module-root = ""
 [project.entry-points."broker.ssh.session"]
 ansible-pylibssh = "broker.binds.pylibssh:Session"
 ssh2-python = "broker.binds.ssh2:Session"
-ssh2-python312 = "broker.binds.ssh2:Session"
 hussh = "broker.binds.hussh:Session"
+paramiko = "broker.binds.paramiko:Session"
 
 [project.entry-points."broker.ssh.interactive_shell"]
 ansible-pylibssh = "broker.binds.pylibssh:InteractiveShell"
 ssh2-python = "broker.binds.ssh2:InteractiveShell"
-ssh2-python312 = "broker.binds.ssh2:InteractiveShell"
+paramiko = "broker.binds.paramiko:InteractiveShell"
 
 [tool.bumpver]
 current_version = "0.7.0"

--- a/tox.toml
+++ b/tox.toml
@@ -99,7 +99,7 @@ commands = [
 description = "Test SSH functionality with hussh backend"
 deps = ["pytest>=8", "pytest-randomly", "docker", "pexpect"]
 extras = ["hussh"]
-set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH_BACKEND = "hussh" }
+set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH__BACKEND = "hussh" }
 pass_env = ["CI", "BROKER_*"]
 allowlist_externals = ["broker"]
 commands_pre = [
@@ -117,7 +117,7 @@ commands = [["pytest", "-v", "{tox_root}/tests/test_ssh.py", "{posargs}"]]
 description = "Test SSH functionality with paramiko backend"
 deps = ["pytest>=8", "pytest-randomly", "docker", "pexpect"]
 extras = ["paramiko"]
-set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH_BACKEND = "paramiko" }
+set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH__BACKEND = "paramiko" }
 pass_env = ["CI", "BROKER_*"]
 allowlist_externals = ["broker"]
 commands_pre = [
@@ -134,8 +134,8 @@ commands = [["pytest", "-v", "{tox_root}/tests/test_ssh.py", "{posargs}"]]
 [env.ssh2-python]
 description = "Test SSH functionality with ssh2-python backend"
 deps = ["pytest>=8", "pytest-randomly", "docker", "pexpect"]
-extras = ["ssh2_python"]
-set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH_BACKEND = "ssh2-python" }
+extras = ["ssh2-python"]
+set_env = { BROKER_DIRECTORY = "{env_tmp_dir}", BROKER_NON_INTERACTIVE = "1", BROKER_SSH__BACKEND = "ssh2-python" }
 pass_env = ["CI", "BROKER_*"]
 allowlist_externals = ["broker"]
 commands_pre = [


### PR DESCRIPTION
Refactoring:
- Removed support for DSS (DSA) keys from the Paramiko bind, aligning with modern SSH security practices.
- Standardized error handling within the Paramiko bind to consistently raise `ParamikoBindError` for Paramiko-specific exceptions, improving error clarity.

Configuration:
- Explicitly registered the Paramiko bind as an available SSH session and interactive shell backend in `pyproject.toml`.
- Removed redundant `ssh2-python312` backend entry points from `pyproject.toml`.
- Corrected the `BROKER_SSH_BACKEND` environment variable to `BROKER_SSH__BACKEND` in `tox.toml` for `hussh`, `paramiko`, and `ssh2-python` test environments to ensure proper backend selection during testing.
- Corrected the `extras` definition for `ssh2-python` in `tox.toml` to `ssh2-python` for consistent package naming.