### PR TITLE
Update project metadata for 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-requires = ["uv_build>=0.7.19,<0.8.0"]
+requires = ["uv_build>=0.7.19"]
 build-backend = "uv_build"
 
 [project]
 name = "broker"
-version = "0.7.0rc3"
+version = "0.7.0"
 description = "The infrastructure middleman."
 readme = "README.md"
 requires-python = ">=3.10"
-keywords = ["broker", "AnsibleTower", "docker", "podman", "beaker"]
+keywords = ["broker", "AnsibleTower", "docker", "podman", "beaker", "openstack"]
 authors = [{ name = "Jacob J Callahan", email = "jacob.callahan05@gmail.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Really not much more than that. This will move us from release candidates to the GA build. Also updated some other metadata and unbound the uv_build upper version limit.