### PR TITLE
Ensure Ansible Tower job templates receive origin metadata

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -795,19 +795,17 @@ class AnsibleTower(Provider):
 
         :return: dictionary containing all information about executed workflow/job template
         """
+        # Use origin passed from broker if available, otherwise find it
+        if "_broker_origin" in kwargs:
+            kwargs["_broker_origin"] = kwargs["_broker_origin"]
+        else:
+            origin = find_origin()
+            kwargs["_broker_origin"] = origin[0]
+            if origin[1]:
+                kwargs["_jenkins_url"] = origin[1]
         if name := kwargs.get("workflow"):
             subject = "workflow"
             get_path = self._v2.workflow_job_templates
-            # Use origin passed from broker if available, otherwise find it
-            if "_broker_origin" in kwargs:
-                kwargs["_broker_origin"] = kwargs["_broker_origin"]
-                if "_jenkins_url" in kwargs:
-                    kwargs["_jenkins_url"] = kwargs["_jenkins_url"]
-            else:
-                origin = find_origin()
-                kwargs["_broker_origin"] = origin[0]
-                if origin[1]:
-                    kwargs["_jenkins_url"] = origin[1]
         elif name := kwargs.get("job_template"):
             subject = "job_template"
             get_path = self._v2.job_templates


### PR DESCRIPTION
Fixes:
- Previously, the logic responsible for propagating `_broker_origin` and `_jenkins_url` was inadvertently scoped only to Ansible Tower workflow executions.
- This fix moves the origin-finding and parameter-setting logic to a common location within the `AnsibleTower` provider's execution path.
- As a result, both workflow job templates and standalone job templates now consistently receive the `_broker_origin` and `_jenkins_url` metadata, ensuring proper tracking and context for all Ansible Tower executions managed by the broker.