### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 description = "The infrastructure middleman."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -39,15 +39,7 @@ Repository = "https://github.com/SatelliteQE/broker"
 ansible_pylibssh = ["ansible-pylibssh"]
 ansibletower = ["awxkit"]
 beaker = ["beaker-client"]
-dev = [
-    "bumpver",
-    "docker",
-    "pexpect",
-    "pre-commit",
-    "pytest",
-    "pytest-randomly",
-    "ruff",
-]
+dev = ["docker", "pexpect", "pre-commit", "pytest", "pytest-randomly", "ruff"]
 docker = ["docker", "paramiko"]
 hussh = ["hussh>=0.1.7"]
 openstack = ["openstacksdk"]
@@ -59,7 +51,6 @@ all = [
     "ansible-pylibssh",
     "awxkit",
     "beaker-client",
-    "bumpver",
     "docker",
     "hussh>=0.1.7",
     "openstacksdk",
@@ -89,21 +80,6 @@ paramiko = "broker.binds.paramiko:Session"
 ansible-pylibssh = "broker.binds.pylibssh:InteractiveShell"
 ssh2-python = "broker.binds.ssh2:InteractiveShell"
 paramiko = "broker.binds.paramiko:InteractiveShell"
-
-[tool.bumpver]
-current_version = "0.7.0"
-version_pattern = "MAJOR.MINOR.PATCH"
-commit_message = "bump version to {new_version}"
-tag_message = "{new_version}"
-tag_scope = "default"
-commit = true
-tag = true
-push = false
-
-[tool.bumpver.file_patterns]
-"pyproject.toml" = ['^version = "{version}"', '^current_version = "{version}"']
-"broker_settings.yaml.example" = ["^_version: {version}"]
-
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -54,15 +54,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/c6/81c16afefcb662e3d6aae070298d603a7783cb9744892e21ba4669123b37/awxkit-24.6.1.tar.gz", hash = "sha256:015421c2c525c5c5dd13890624f453ac3fc7ca2bc3e301b82db871bc4b8da23c", size = 106296, upload-time = "2024-07-02T21:51:56.435Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/cc/44ba38a631459824c37424f1eda9dac7deefaaabf32f6c92cc2307562eb4/awxkit-24.6.1-py3-none-any.whl", hash = "sha256:7baecf5ef3a2b35ec7840c401eb578d4bbfac2f85974f34d2644c9c434515c51", size = 124231, upload-time = "2024-07-02T21:51:49.216Z" },
-]
-
-[[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -152,28 +143,48 @@ wheels = [
 
 [[package]]
 name = "broker"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
-    { name = "awxkit" },
     { name = "click" },
     { name = "dynaconf" },
     { name = "logzero" },
     { name = "packaging" },
+    { name = "requests" },
     { name = "rich" },
     { name = "rich-click" },
     { name = "ruamel-yaml" },
-    { name = "setuptools" },
-    { name = "ssh2-python" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "ansible-pylibssh" },
+    { name = "awxkit" },
+    { name = "beaker-client" },
+    { name = "bumpver" },
+    { name = "docker" },
+    { name = "hussh" },
+    { name = "openstacksdk" },
+    { name = "paramiko" },
+    { name = "pexpect" },
+    { name = "podman" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-randomly" },
+    { name = "ruff" },
+    { name = "ssh2-python" },
+]
 ansible-pylibssh = [
     { name = "ansible-pylibssh" },
+]
+ansibletower = [
+    { name = "awxkit" },
 ]
 beaker = [
     { name = "beaker-client" },
 ]
 dev = [
+    { name = "bumpver" },
     { name = "docker" },
     { name = "pexpect" },
     { name = "pre-commit" },
@@ -188,15 +199,19 @@ docker = [
 hussh = [
     { name = "hussh" },
 ]
+openstack = [
+    { name = "openstacksdk" },
+]
 paramiko = [
     { name = "paramiko" },
 ]
 podman = [
     { name = "podman" },
 ]
-setup = [
-    { name = "build" },
-    { name = "twine" },
+satlab = [
+    { name = "awxkit" },
+    { name = "hussh" },
+    { name = "podman" },
 ]
 ssh2-python = [
     { name = "ssh2-python" },
@@ -204,49 +219,65 @@ ssh2-python = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansible-pylibssh", marker = "extra == 'all'" },
     { name = "ansible-pylibssh", marker = "extra == 'ansible-pylibssh'" },
-    { name = "awxkit" },
+    { name = "awxkit", marker = "extra == 'all'" },
+    { name = "awxkit", marker = "extra == 'ansibletower'" },
+    { name = "awxkit", marker = "extra == 'satlab'" },
+    { name = "beaker-client", marker = "extra == 'all'" },
     { name = "beaker-client", marker = "extra == 'beaker'" },
-    { name = "build", marker = "extra == 'setup'" },
+    { name = "bumpver", marker = "extra == 'all'" },
+    { name = "bumpver", marker = "extra == 'dev'" },
     { name = "click" },
+    { name = "docker", marker = "extra == 'all'" },
     { name = "docker", marker = "extra == 'dev'" },
     { name = "docker", marker = "extra == 'docker'" },
     { name = "dynaconf", specifier = ">=3.1.6,<4.0.0" },
+    { name = "hussh", marker = "extra == 'all'", specifier = ">=0.1.7" },
     { name = "hussh", marker = "extra == 'hussh'", specifier = ">=0.1.7" },
+    { name = "hussh", marker = "extra == 'satlab'", specifier = ">=0.1.7" },
     { name = "logzero" },
+    { name = "openstacksdk", marker = "extra == 'all'" },
+    { name = "openstacksdk", marker = "extra == 'openstack'" },
     { name = "packaging" },
+    { name = "paramiko", marker = "extra == 'all'" },
     { name = "paramiko", marker = "extra == 'docker'" },
     { name = "paramiko", marker = "extra == 'paramiko'" },
+    { name = "pexpect", marker = "extra == 'all'" },
     { name = "pexpect", marker = "extra == 'dev'" },
+    { name = "podman", marker = "extra == 'all'", specifier = ">=5.2" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.2" },
+    { name = "podman", marker = "extra == 'satlab'", specifier = ">=5.2" },
+    { name = "pre-commit", marker = "extra == 'all'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'all'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-randomly", marker = "extra == 'all'" },
     { name = "pytest-randomly", marker = "extra == 'dev'" },
+    { name = "requests" },
     { name = "rich" },
     { name = "rich-click" },
     { name = "ruamel-yaml" },
+    { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "setuptools" },
-    { name = "ssh2-python" },
+    { name = "ssh2-python", marker = "extra == 'all'" },
     { name = "ssh2-python", marker = "extra == 'ssh2-python'" },
-    { name = "twine", marker = "extra == 'setup'" },
 ]
-provides-extras = ["beaker", "dev", "docker", "podman", "setup", "ssh2-python", "ansible-pylibssh", "hussh", "paramiko"]
+provides-extras = ["ansible-pylibssh", "ansibletower", "beaker", "dev", "docker", "hussh", "openstack", "paramiko", "podman", "ssh2-python", "satlab", "all"]
 
 [[package]]
-name = "build"
-version = "1.2.2.post1"
+name = "bumpver"
+version = "2025.1131"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "lexid" },
+    { name = "toml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701, upload-time = "2024-10-06T17:22:25.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc13e816e9f0849dce423b904b06fd91b5444cba6df3200d512a702f2e95/bumpver-2025.1131.tar.gz", hash = "sha256:a35fd2d43a5f65f014035c094866bd3bd6c739606f29fd41246d6ec6e839d3f9", size = 115372, upload-time = "2025-07-02T20:36:11.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950, upload-time = "2024-10-06T17:22:23.299Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5b/2d5ea6802495ee4506721977be522804314aa66ad629d9356e3c7e5af4a6/bumpver-2025.1131-py2.py3-none-any.whl", hash = "sha256:c02527f6ed7887afbc06c07630047b24a9f9d02d544a65639e99bf8b92aaa674", size = 65361, upload-time = "2025-07-02T20:36:10.103Z" },
 ]
 
 [[package]]
@@ -484,12 +515,17 @@ wheels = [
 ]
 
 [[package]]
-name = "docutils"
-version = "0.21.2"
+name = "dogpile-cache"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+dependencies = [
+    { name = "decorator" },
+    { name = "stevedore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/c8/301ff89746e76745b937606df4753c032787c59ecb37dd4d4250bddc8929/dogpile_cache-1.5.0.tar.gz", hash = "sha256:849c5573c9a38f155cd4173103c702b637ede0361c12e864876877d0cd125eec", size = 947962, upload-time = "2025-10-11T17:35:36.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/80/12235e5b75bb2c586733280854f131b86051e0bbdfb55349ff70d0f72cf9/dogpile_cache-1.5.0-py3-none-any.whl", hash = "sha256:dc7b47d37844db15e8fdc0243c1b58857a2ddc52a5118237a97127bac200e18d", size = 64447, upload-time = "2025-10-11T17:35:38.573Z" },
 ]
 
 [[package]]
@@ -563,6 +599,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/09/bc3855a148b510f4818af8e156cf861c79ef5a43515ef425d7b03451cb0e/hussh-0.1.8-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:6c98adb29802e937d4aa5bf7bdd976e85bd68503358025106c626e250aebddb8", size = 1855224, upload-time = "2024-11-24T18:40:54.801Z" },
     { url = "https://files.pythonhosted.org/packages/7a/92/a48d85709cbfc2adb7adf8335072fb5b0330c9a68cf0f4c10d99f8548dcb/hussh-0.1.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:20d5309804eff07023db906e469d44a6e3e90c8104bbca437a19e2dd56948702", size = 1988955, upload-time = "2024-11-24T18:41:07.216Z" },
     { url = "https://files.pythonhosted.org/packages/d7/41/9a2245331623b490266e1e84ec229ea56ca76211ec36acda87325c7520bd/hussh-0.1.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a3089c8162f2817ae93766c0989c4f19db3d8d3f7a5471d22e0f8745e5c629f7", size = 2083614, upload-time = "2024-11-24T18:41:19.887Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/2cac21dd34a52471e83843aa7d04250b62c63ef39d36e351cdab68eaa470/hussh-0.1.8-cp310-cp310-win_amd64.whl", hash = "sha256:df469618418045b455fae3c207c2eba6c1469abe1a6d901fadddf66fe0a86adf", size = 298869, upload-time = "2025-10-09T18:49:59.461Z" },
     { url = "https://files.pythonhosted.org/packages/a3/09/bc85b16f8a47d44e1740fa2480ed3cdc4c64a0c7f7e4c604b1ce7c797527/hussh-0.1.8-cp310-none-win_amd64.whl", hash = "sha256:e0c5f8db836d9d02da07919904cbfce5b30301c30360c5b1ff95bc3020b34a4c", size = 301302, upload-time = "2024-11-24T18:41:32.741Z" },
     { url = "https://files.pythonhosted.org/packages/fc/32/5c5dc7c5a775a15f42b1afdfb525beb52aa5058d6a7004d6d33433bd983a/hussh-0.1.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:578990a61a306eea409c2842f69527984359eb910044db06ce31ec7f032f6d6b", size = 1685895, upload-time = "2024-11-24T18:40:30.063Z" },
     { url = "https://files.pythonhosted.org/packages/bd/27/a31e124b188f2ccd0d372dc2fa325516d4d1a699914a9b959eecdca4b131/hussh-0.1.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1d0beec191a2f37245592bfd2c56a3b88229b904140905160cd3745f784d144d", size = 2012280, upload-time = "2024-11-24T18:40:18.621Z" },
@@ -575,6 +612,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/da/bf8a2bb440c46c3270cf2f524789b01966ad1db8087695e54a6a59c3c64d/hussh-0.1.8-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:78e4cdde8016d9d1b94880d62328ea86ea822ec8d1ba9952018c7bb36a73ae63", size = 1855224, upload-time = "2024-11-24T18:40:56.81Z" },
     { url = "https://files.pythonhosted.org/packages/3d/8f/4c5660aa1c2f4f24d87865852369ec101d55af07817b700af0e36d303388/hussh-0.1.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ddbcabefa45a42dd02c4cf1ed7721c7499d5792d1fc9acf2c8dcd88c82998af8", size = 1988959, upload-time = "2024-11-24T18:41:08.535Z" },
     { url = "https://files.pythonhosted.org/packages/7f/9f/5fd237245d57d8eecff6c0b36f72426c69e11e5019207bb2f91ed661967c/hussh-0.1.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:feefcbfa1e7a70854022de93172f30cfb33bae9e2fd3a63b68206ca229504b8f", size = 2083619, upload-time = "2024-11-24T18:41:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a9/7f8c720a9949b27209744a3c7041e197cff3fe831170abc295bca62543b9/hussh-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:5f64715fb33e793feb6a89e11d82f97fd16c19202cf224a403fdd220be7faf34", size = 298730, upload-time = "2025-10-09T18:50:00.787Z" },
     { url = "https://files.pythonhosted.org/packages/aa/58/b869653669eabb7286d255bc6ca1724a7c1140827175df4f049f9eeeaa50/hussh-0.1.8-cp311-none-win_amd64.whl", hash = "sha256:fe76f52f3144f7017592268cabddf5199ad18462b37eb87ffb71af96f0e1efe5", size = 301283, upload-time = "2024-11-24T18:41:33.962Z" },
     { url = "https://files.pythonhosted.org/packages/34/23/ba38efc6eda2fd07e8d165f8c6f1ae7d6c1702813f7f2054e31316767ac1/hussh-0.1.8-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d315285860942330e413e2a29debc3eab2c74f81af8a69b722230c22bcb48df7", size = 1685897, upload-time = "2024-11-24T18:40:31.3Z" },
     { url = "https://files.pythonhosted.org/packages/8b/8f/5d64216228fc9afee984df07c5092640648fb9c6acf80a1927d88b7e4e27/hussh-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:657ee4ad4546ce4454987fd68189cbad3b399e362aa7302b9d59bb0698d9c088", size = 2012277, upload-time = "2024-11-24T18:40:19.869Z" },
@@ -587,6 +625,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/aa/84664359c5cf055a8e995d6552d37eef4fc26d67110c4baa9417de526b19/hussh-0.1.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:30156e87eec435f1f8629ca2391d77d0611f40229f46f516f918ccd86d109a1b", size = 1855226, upload-time = "2024-11-24T18:40:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/16/70/27d78dd222eedbfcd561f03eae70965c1288f2de26bd784bee978b4f02fe/hussh-0.1.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d013dd74313ad31e5be12a80a9ff84b54db911558e284b94f9236ec6e141a4df", size = 1988959, upload-time = "2024-11-24T18:41:10.593Z" },
     { url = "https://files.pythonhosted.org/packages/cc/5f/8cb51c0531ff925729d2535b51f5a9bc8c757b45a7a89979ffd13f307efb/hussh-0.1.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34cb571ece99be062ba1ba191ac266bc075a13439aaa5cf369cd6a42399ca884", size = 2083618, upload-time = "2024-11-24T18:41:22.506Z" },
+    { url = "https://files.pythonhosted.org/packages/55/76/dfb30a0b4be2758b307fc0fb9ba9a63200bae3e14827cc10ae93128fb907/hussh-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:66e560d5c99deb57d4ac23b05406fe32987885024bc67639aadf4974c4ffb01c", size = 299257, upload-time = "2025-10-09T18:50:02.055Z" },
     { url = "https://files.pythonhosted.org/packages/c2/c9/e53656932ec7ea6c2e65166f2a1f5f65309536820b890d573ab216260a02/hussh-0.1.8-cp312-none-win_amd64.whl", hash = "sha256:c2fb37edd8af33bc290fd68d9b0b145bb1163d6e33fd07c3e874dcabce263600", size = 301732, upload-time = "2024-11-24T18:41:35.091Z" },
     { url = "https://files.pythonhosted.org/packages/29/73/d4372d381762a938af674c1e4f4af4274a821b78c75a1479639d744c19d4/hussh-0.1.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:bbdee97273b1cbb5fb4ffd0f5ee441f261d6893effa946fd96f80b910415e677", size = 1685897, upload-time = "2024-11-24T18:40:33.172Z" },
     { url = "https://files.pythonhosted.org/packages/7f/5d/37ea76886b56bb1a055d7316699ff6c8c4229af5a50b0edcecd01141e310/hussh-0.1.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1caf522ecb17b73005f489539fb0aaef1e189b944e12f417f48aa4759aaf439c", size = 2012278, upload-time = "2024-11-24T18:40:21.158Z" },
@@ -599,6 +638,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/d4/e0bd9ba6bf38092321782483f8a41b69268afc07f87e72e7ea14ac5cd3e4/hussh-0.1.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:e027478b6d43499fed8fd02a3df02f2b34cd5867320f458a6e6b775afd78c364", size = 1855226, upload-time = "2024-11-24T18:40:59.459Z" },
     { url = "https://files.pythonhosted.org/packages/d7/20/81e2d9d026cf3fffd299120966d3e4561bd32d5a7985969be243f312d4eb/hussh-0.1.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e4fb9945b04db3ee6732e879cd6b99eb377dcfca8a9cc75aa4f1ea54ef4bb693", size = 1988959, upload-time = "2024-11-24T18:41:12.189Z" },
     { url = "https://files.pythonhosted.org/packages/b0/95/f2e302e4f3ee43a92155ae295a8e4fc4f0f2476de0f65be9a4a9a4b8035b/hussh-0.1.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:05064854da17f2eb000109f6446db07d97d41d7ec029b9e39804b371ddea01d0", size = 2083617, upload-time = "2024-11-24T18:41:23.825Z" },
+    { url = "https://files.pythonhosted.org/packages/69/6c/1d95b23ee2f4e60541e9c966859b391824c16a050f15bfe7731fcb54d77d/hussh-0.1.8-cp313-cp313-win_amd64.whl", hash = "sha256:801d4bb5f0a1ae8720c664f9076ef0ef967a70e03aeab870d00be9e66edd4529", size = 298875, upload-time = "2025-10-09T18:50:03.751Z" },
+    { url = "https://files.pythonhosted.org/packages/40/42/fc7276e55ccfc83c1560d84a2dda05136d83a2cde201cf2f3ca877b24ab9/hussh-0.1.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a2cc7f99712b999d7fd9d06b4af7eceb1116d368b3cf650ac88ffc16a1588537", size = 1793996, upload-time = "2025-10-09T18:49:45.604Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b1/e2fb20dd3abb2992996d8f08da0d8600009ce56d5f18cb67c7f6dc5d58e9/hussh-0.1.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:872b68e0e6e18118c3adadb88f7ba9cce2b877ce8bc23606884a85e43a54531c", size = 2107207, upload-time = "2025-10-09T18:49:42.693Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/01/e4a95917f66df9dce1cd45f24357d246438d2816db5c1dbadb339cef40a1/hussh-0.1.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef3aaa84524f2b25d57ecbc8478c668288054ea1095e72de30d7be5bcd67ac1c", size = 2320715, upload-time = "2025-10-09T18:49:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ce/a244c83b5bc9694a6fbc932a4f5abb574da17b8cdabe50c5749ed82f89d1/hussh-0.1.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:436437c13d0f860f3069581c3d9449ea4d213c5492c35d6e5434cc75e7aa2d17", size = 1699017, upload-time = "2025-10-09T18:49:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/fb/aca90405b13afda49fa7be68c73edcd01001f7c3ea667180caa5feba97e0/hussh-0.1.8-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4cf642a887162468b5046dcc00f88820360b938e73094ea8a513e2d843cd5a4c", size = 1970817, upload-time = "2025-10-09T18:49:36.435Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/51/c12a920b16ec05383b04baaa29b9441d63fc2371da4a31aaa16dce8b503f/hussh-0.1.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:07bf00dcc5c6de49f76408921cb2b4fa9f023d1f22d56e98dd7c72fba878e0a8", size = 1994970, upload-time = "2025-10-09T18:49:33.327Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7b/d30f773c0cf917509b59e473c1c320414d410ab2387d7c18f1c7f5572164/hussh-0.1.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792e6acbfefd05f1b09ea18049476df37bb8fd08ff5c09c72c2323828b5c5ad9", size = 2028698, upload-time = "2025-10-09T18:49:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7f/e53d67a826ca431859905f1d02fba716a74a76eed781aa75cc800cd77ce9/hussh-0.1.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c2006303c32eb1e7c62cb4de7ee2cfaebecb27f7806d3b5ab668c3fcec78b18", size = 2635037, upload-time = "2025-10-09T18:49:48.42Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/6236a1f3bdbeec4abeffc7464a3082bdbd9ae7694d39fe3820633d662e6d/hussh-0.1.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:179c0ed8d3881ea5f05d22988709f1a1f1326fe27b4bb7f3577ed24bab27c023", size = 1987803, upload-time = "2025-10-09T18:49:51.283Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/0c/9b635ee49df35418def55b2af913df24642aab00d993dbd7f67ffd313800/hussh-0.1.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:93e14895930cfd5c67385782056700a375aae8208829d644eb75869d136dfa96", size = 2152146, upload-time = "2025-10-09T18:49:54.134Z" },
+    { url = "https://files.pythonhosted.org/packages/76/72/224d8fa732ca38cf9ec4aad9245e7f55f2c442f09de4b6a318492f9c8b50/hussh-0.1.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:34d2c06f5931c9a48f126f116dad91b4c1e28e5cad347c36c2dd673cb773c979", size = 2253749, upload-time = "2025-10-09T18:49:57.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/40/ebb296aaabfa19189e0b7c7f1c4980f7c296f15a627fae0e7509091b4491/hussh-0.1.8-cp314-cp314-win_amd64.whl", hash = "sha256:5501542ff1edeab865114231e1ecc53dfea0fad5c8baaaadccd9da8e79444da5", size = 299137, upload-time = "2025-10-09T18:50:05.079Z" },
     { url = "https://files.pythonhosted.org/packages/91/5f/99a62c6382fe07e5e1edf9c4a4f5ffa389e7e7249697a4712ef167441a3f/hussh-0.1.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:10ed4bc62eb65b54816df213c97f0f912389e46757bbb8a9bea616a2fde2f721", size = 1685908, upload-time = "2024-11-24T18:40:37.402Z" },
     { url = "https://files.pythonhosted.org/packages/04/66/c4280d443898ba9feaeb8019a51dfc745e2b8bbc4b18ec1885a6ef6a3cb5/hussh-0.1.8-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:aa99f173a5cbcf93ef6c5e35131002f399cb0db6c8a7c82ca5ed5da8c6b06adb", size = 2012292, upload-time = "2024-11-24T18:40:25.723Z" },
     { url = "https://files.pythonhosted.org/packages/e0/73/bbee4c8b94c3139d3bb4d43e80266029164c6930b4f438de56dfa8b046a0/hussh-0.1.8-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce679b48efe07047678284aefc76e1ae73ecdad210ded4c33d8fa98e49c54132", size = 2190732, upload-time = "2024-11-24T18:39:22.46Z" },
@@ -610,18 +662,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/8f/6a3801e93a698b0d6606fa153803737d06a9a37e7a2370328c355eb7baa6/hussh-0.1.8-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:39b6319ae5196610394e70e9a493d5518afc3abc4ca58742cc61f39b683d23c9", size = 1855215, upload-time = "2024-11-24T18:41:04.475Z" },
     { url = "https://files.pythonhosted.org/packages/a4/5e/7cbec99aeb72471ace8c947d9629683007c3211956426cd500c5f2f4e476/hussh-0.1.8-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e124e04ea643534be79e3ca067cc92d7c132a2eed3bccdfc95d5bd057848d46c", size = 1988964, upload-time = "2024-11-24T18:41:16.354Z" },
     { url = "https://files.pythonhosted.org/packages/d5/a4/0857cbd3b38b6d4f97653f2a9aa2d21e255dbebd874100851725f042793d/hussh-0.1.8-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5236690cad74b41bfb8dbc9bbd7650f2a2179870de43d2e8c4325fdaa21a574e", size = 2083625, upload-time = "2024-11-24T18:41:27.74Z" },
-]
-
-[[package]]
-name = "id"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/11/102da08f88412d875fa2f1a9a469ff7ad4c874b0ca6fed0048fe385bdb3d/id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d", size = 15237, upload-time = "2024-12-04T19:53:05.575Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658", size = 13611, upload-time = "2024-12-04T19:53:03.02Z" },
 ]
 
 [[package]]
@@ -643,18 +683,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -664,48 +692,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jaraco-classes"
-version = "3.4.0"
+name = "iso8601"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f3/ef59cee614d5e0accf6fd0cbba025b93b272e626ca89fb70a3e9187c5d15/iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df", size = 6522, upload-time = "2023-10-03T00:25:39.317Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159, upload-time = "2024-09-27T19:47:09.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649", size = 10187, upload-time = "2024-09-27T19:47:07.14Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242", size = 7545, upload-time = "2023-10-03T00:25:32.304Z" },
 ]
 
 [[package]]
@@ -721,21 +713,59 @@ wheels = [
 ]
 
 [[package]]
-name = "keyring"
-version = "25.6.0"
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+    { name = "jsonpointer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload-time = "2024-12-25T15:26:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "keystoneauth1"
+version = "5.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "iso8601" },
+    { name = "os-service-types" },
+    { name = "pbr" },
+    { name = "requests" },
+    { name = "stevedore" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/16/b96df223ca7ea4bfa78034b205e0eaf4875bfecb2f119f375fc5232d2061/keystoneauth1-5.12.0.tar.gz", hash = "sha256:dd113c2f3dcb418d9f761c73b8cd43a96ddfa8a612b51c576822381f39ca4ae8", size = 288504, upload-time = "2025-08-21T09:34:10.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8a/803a45dc660770ac7e2d74fc1260a15ade29d2234120854747491b4a7a02/keystoneauth1-5.12.0-py3-none-any.whl", hash = "sha256:2e514b03615e2d9162f0c07c823a61a636e6d4df38ff4a34b7511a04e8a4166a", size = 343402, upload-time = "2025-08-21T09:34:09.38Z" },
+]
+
+[[package]]
+name = "lexid"
+version = "2021.1006"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/0b/28a3f9abc75abbf1fa996eb2dd77e1e33a5d1aac62566e3f60a8ec8b8a22/lexid-2021.1006.tar.gz", hash = "sha256:509a3a4cc926d3dbf22b203b18a4c66c25e6473fb7c0e0d30374533ac28bafe5", size = 11525, upload-time = "2021-04-02T20:18:34.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/e3/35764404a4b7e2021be1f88f42264c2e92e0c4720273559a62461ce64a47/lexid-2021.1006-py2.py3-none-any.whl", hash = "sha256:5526bb5606fd74c7add23320da5f02805bddd7c77916f2dc1943e6bada8605ed", size = 7587, upload-time = "2021-04-02T20:18:33.129Z" },
 ]
 
 [[package]]
@@ -912,52 +942,50 @@ wheels = [
 ]
 
 [[package]]
-name = "more-itertools"
-version = "10.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
-]
-
-[[package]]
-name = "nh3"
-version = "0.2.21"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/30/2f81466f250eb7f591d4d193930df661c8c23e9056bdc78e365b646054d8/nh3-0.2.21.tar.gz", hash = "sha256:4990e7ee6a55490dbf00d61a6f476c9a3258e31e711e13713b2ea7d6616f670e", size = 16581, upload-time = "2025-02-25T13:38:44.619Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/81/b83775687fcf00e08ade6d4605f0be9c4584cb44c4973d9f27b7456a31c9/nh3-0.2.21-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:fcff321bd60c6c5c9cb4ddf2554e22772bb41ebd93ad88171bbbb6f271255286", size = 1297678, upload-time = "2025-02-25T13:37:56.063Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ee/d0ad8fb4b5769f073b2df6807f69a5e57ca9cea504b78809921aef460d20/nh3-0.2.21-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31eedcd7d08b0eae28ba47f43fd33a653b4cdb271d64f1aeda47001618348fde", size = 733774, upload-time = "2025-02-25T13:37:58.419Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/76/b450141e2d384ede43fe53953552f1c6741a499a8c20955ad049555cabc8/nh3-0.2.21-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d426d7be1a2f3d896950fe263332ed1662f6c78525b4520c8e9861f8d7f0d243", size = 760012, upload-time = "2025-02-25T13:38:01.017Z" },
-    { url = "https://files.pythonhosted.org/packages/97/90/1182275db76cd8fbb1f6bf84c770107fafee0cb7da3e66e416bcb9633da2/nh3-0.2.21-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9d67709bc0d7d1f5797b21db26e7a8b3d15d21c9c5f58ccfe48b5328483b685b", size = 923619, upload-time = "2025-02-25T13:38:02.617Z" },
-    { url = "https://files.pythonhosted.org/packages/29/c7/269a7cfbec9693fad8d767c34a755c25ccb8d048fc1dfc7a7d86bc99375c/nh3-0.2.21-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:55823c5ea1f6b267a4fad5de39bc0524d49a47783e1fe094bcf9c537a37df251", size = 1000384, upload-time = "2025-02-25T13:38:04.402Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a9/48479dbf5f49ad93f0badd73fbb48b3d769189f04c6c69b0df261978b009/nh3-0.2.21-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:818f2b6df3763e058efa9e69677b5a92f9bc0acff3295af5ed013da544250d5b", size = 918908, upload-time = "2025-02-25T13:38:06.693Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/da/0279c118f8be2dc306e56819880b19a1cf2379472e3b79fc8eab44e267e3/nh3-0.2.21-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b3b5c58161e08549904ac4abd450dacd94ff648916f7c376ae4b2c0652b98ff9", size = 909180, upload-time = "2025-02-25T13:38:10.941Z" },
-    { url = "https://files.pythonhosted.org/packages/26/16/93309693f8abcb1088ae143a9c8dbcece9c8f7fb297d492d3918340c41f1/nh3-0.2.21-cp313-cp313t-win32.whl", hash = "sha256:637d4a10c834e1b7d9548592c7aad760611415fcd5bd346f77fd8a064309ae6d", size = 532747, upload-time = "2025-02-25T13:38:12.548Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/3a/96eb26c56cbb733c0b4a6a907fab8408ddf3ead5d1b065830a8f6a9c3557/nh3-0.2.21-cp313-cp313t-win_amd64.whl", hash = "sha256:713d16686596e556b65e7f8c58328c2df63f1a7abe1277d87625dcbbc012ef82", size = 528908, upload-time = "2025-02-25T13:38:14.059Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/1d/b1ef74121fe325a69601270f276021908392081f4953d50b03cbb38b395f/nh3-0.2.21-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a772dec5b7b7325780922dd904709f0f5f3a79fbf756de5291c01370f6df0967", size = 1316133, upload-time = "2025-02-25T13:38:16.601Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/f2/2c7f79ce6de55b41e7715f7f59b159fd59f6cdb66223c05b42adaee2b645/nh3-0.2.21-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d002b648592bf3033adfd875a48f09b8ecc000abd7f6a8769ed86b6ccc70c759", size = 758328, upload-time = "2025-02-25T13:38:18.972Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ad/07bd706fcf2b7979c51b83d8b8def28f413b090cf0cb0035ee6b425e9de5/nh3-0.2.21-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2a5174551f95f2836f2ad6a8074560f261cf9740a48437d6151fd2d4d7d617ab", size = 747020, upload-time = "2025-02-25T13:38:20.571Z" },
-    { url = "https://files.pythonhosted.org/packages/75/99/06a6ba0b8a0d79c3d35496f19accc58199a1fb2dce5e711a31be7e2c1426/nh3-0.2.21-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b8d55ea1fc7ae3633d758a92aafa3505cd3cc5a6e40470c9164d54dff6f96d42", size = 944878, upload-time = "2025-02-25T13:38:22.204Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d4/dc76f5dc50018cdaf161d436449181557373869aacf38a826885192fc587/nh3-0.2.21-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ae319f17cd8960d0612f0f0ddff5a90700fa71926ca800e9028e7851ce44a6f", size = 903460, upload-time = "2025-02-25T13:38:25.951Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c3/d4f8037b2ab02ebf5a2e8637bd54736ed3d0e6a2869e10341f8d9085f00e/nh3-0.2.21-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ca02ac6f27fc80f9894409eb61de2cb20ef0a23740c7e29f9ec827139fa578", size = 839369, upload-time = "2025-02-25T13:38:28.174Z" },
-    { url = "https://files.pythonhosted.org/packages/11/a9/1cd3c6964ec51daed7b01ca4686a5c793581bf4492cbd7274b3f544c9abe/nh3-0.2.21-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5f77e62aed5c4acad635239ac1290404c7e940c81abe561fd2af011ff59f585", size = 739036, upload-time = "2025-02-25T13:38:30.539Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/04/bfb3ff08d17a8a96325010ae6c53ba41de6248e63cdb1b88ef6369a6cdfc/nh3-0.2.21-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:087ffadfdcd497658c3adc797258ce0f06be8a537786a7217649fc1c0c60c293", size = 768712, upload-time = "2025-02-25T13:38:32.992Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/aa/cfc0bf545d668b97d9adea4f8b4598667d2b21b725d83396c343ad12bba7/nh3-0.2.21-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ac7006c3abd097790e611fe4646ecb19a8d7f2184b882f6093293b8d9b887431", size = 930559, upload-time = "2025-02-25T13:38:35.204Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9d/6f5369a801d3a1b02e6a9a097d56bcc2f6ef98cffebf03c4bb3850d8e0f0/nh3-0.2.21-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:6141caabe00bbddc869665b35fc56a478eb774a8c1dfd6fba9fe1dfdf29e6efa", size = 1008591, upload-time = "2025-02-25T13:38:37.099Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/df/01b05299f68c69e480edff608248313cbb5dbd7595c5e048abe8972a57f9/nh3-0.2.21-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:20979783526641c81d2f5bfa6ca5ccca3d1e4472474b162c6256745fbfe31cd1", size = 925670, upload-time = "2025-02-25T13:38:38.696Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/79/bdba276f58d15386a3387fe8d54e980fb47557c915f5448d8c6ac6f7ea9b/nh3-0.2.21-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a7ea28cd49293749d67e4fcf326c554c83ec912cd09cd94aa7ec3ab1921c8283", size = 917093, upload-time = "2025-02-25T13:38:40.249Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/d8/c6f977a5cd4011c914fb58f5ae573b071d736187ccab31bfb1d539f4af9f/nh3-0.2.21-cp38-abi3-win32.whl", hash = "sha256:6c9c30b8b0d291a7c5ab0967ab200598ba33208f754f2f4920e9343bdd88f79a", size = 537623, upload-time = "2025-02-25T13:38:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/23/fc/8ce756c032c70ae3dd1d48a3552577a325475af2a2f629604b44f571165c/nh3-0.2.21-cp38-abi3-win_amd64.whl", hash = "sha256:bb0014948f04d7976aabae43fcd4cb7f551f9f8ce785a4c9ef66e6c2590f8629", size = 535283, upload-time = "2025-02-25T13:38:43.355Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "openstacksdk"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "decorator" },
+    { name = "dogpile-cache" },
+    { name = "iso8601" },
+    { name = "jmespath" },
+    { name = "jsonpatch" },
+    { name = "keystoneauth1" },
+    { name = "os-service-types" },
+    { name = "pbr" },
+    { name = "platformdirs" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "requestsexceptions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/24/1167097740136e302c74043c1c6feecf8d757b052d7b457960e0dc60fa03/openstacksdk-4.8.0.tar.gz", hash = "sha256:4dc038e1c17d893005f3a0a8951456afd9d148f3f65d448f94adcceb278d7f31", size = 1309981, upload-time = "2025-11-13T13:59:59.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/45/87fa873f35abdf191d66d4821fe965f781e2d3e37e58883c6e23e95fa794/openstacksdk-4.8.0-py3-none-any.whl", hash = "sha256:7f7c438d418a4ee0c8737b1ac0859b3c1e8e21401677782415d21bce3324b9dd", size = 1849694, upload-time = "2025-11-13T13:59:57.634Z" },
+]
+
+[[package]]
+name = "os-service-types"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pbr" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/da/66eaa235e053eb2451464ec131487dec01b5259105688e9f6771d07d45fe/os_service_types-1.8.1.tar.gz", hash = "sha256:c3d60134ee509cf55452c73ff8bd41891bcb6cf42421a159c0138824e126402b", size = 27348, upload-time = "2025-10-30T10:01:03.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/86/9fc6f238d5a14a90ac8dacb051072aab694e91de76d4b8be56fd4dba4cf4/os_service_types-1.8.1-py3-none-any.whl", hash = "sha256:348e029248fccf063a117d30ac603d1afa396fda436bdbfa71f90ae920f13511", size = 24734, upload-time = "2025-10-30T10:01:02.189Z" },
 ]
 
 [[package]]
@@ -981,6 +1009,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/15/ad6ce226e8138315f2451c2aeea985bf35ee910afb477bae7477dc3a8f3b/paramiko-3.5.1.tar.gz", hash = "sha256:b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822", size = 1566110, upload-time = "2025-02-04T02:37:59.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/f8/c7bd0ef12954a81a1d3cea60a13946bd9a49a0036a5927770c461eade7ae/paramiko-3.5.1-py3-none-any.whl", hash = "sha256:43b9a0501fc2b5e70680388d9346cf252cfb7d00b0667c39e80eb43a408b8f61", size = 227298, upload-time = "2025-02-04T02:37:57.672Z" },
+]
+
+[[package]]
+name = "pbr"
+version = "7.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ab/1de9a4f730edde1bdbbc2b8d19f8fa326f036b4f18b2f72cfbea7dc53c26/pbr-7.0.3.tar.gz", hash = "sha256:b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29", size = 135625, upload-time = "2025-11-03T17:04:56.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl", hash = "sha256:ff223894eb1cd271a98076b13d3badff3bb36c424074d26334cd25aebeecea6b", size = 131898, upload-time = "2025-11-03T17:04:54.875Z" },
 ]
 
 [[package]]
@@ -1056,6 +1096,32 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/88/bdd0a41e5857d5d703287598cbf08dad90aed56774ea52ae071bae9071b6/psutil-7.1.3.tar.gz", hash = "sha256:6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74", size = 489059, upload-time = "2025-11-02T12:25:54.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/93/0c49e776b8734fef56ec9c5c57f923922f2cf0497d62e0f419465f28f3d0/psutil-7.1.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0005da714eee687b4b8decd3d6cc7c6db36215c9e74e5ad2264b90c3df7d92dc", size = 239751, upload-time = "2025-11-02T12:25:58.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8d/b31e39c769e70780f007969815195a55c81a63efebdd4dbe9e7a113adb2f/psutil-7.1.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19644c85dcb987e35eeeaefdc3915d059dac7bd1167cdcdbf27e0ce2df0c08c0", size = 240368, upload-time = "2025-11-02T12:26:00.491Z" },
+    { url = "https://files.pythonhosted.org/packages/62/61/23fd4acc3c9eebbf6b6c78bcd89e5d020cfde4acf0a9233e9d4e3fa698b4/psutil-7.1.3-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95ef04cf2e5ba0ab9eaafc4a11eaae91b44f4ef5541acd2ee91d9108d00d59a7", size = 287134, upload-time = "2025-11-02T12:26:02.613Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1c/f921a009ea9ceb51aa355cb0cc118f68d354db36eae18174bab63affb3e6/psutil-7.1.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1068c303be3a72f8e18e412c5b2a8f6d31750fb152f9cb106b54090296c9d251", size = 289904, upload-time = "2025-11-02T12:26:05.207Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/82/62d68066e13e46a5116df187d319d1724b3f437ddd0f958756fc052677f4/psutil-7.1.3-cp313-cp313t-win_amd64.whl", hash = "sha256:18349c5c24b06ac5612c0428ec2a0331c26443d259e2a0144a9b24b4395b58fa", size = 249642, upload-time = "2025-11-02T12:26:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ad/c1cd5fe965c14a0392112f68362cfceb5230819dbb5b1888950d18a11d9f/psutil-7.1.3-cp313-cp313t-win_arm64.whl", hash = "sha256:c525ffa774fe4496282fb0b1187725793de3e7c6b29e41562733cae9ada151ee", size = 245518, upload-time = "2025-11-02T12:26:09.719Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/bb/6670bded3e3236eb4287c7bcdc167e9fae6e1e9286e437f7111caed2f909/psutil-7.1.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b403da1df4d6d43973dc004d19cee3b848e998ae3154cc8097d139b77156c353", size = 239843, upload-time = "2025-11-02T12:26:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/66/853d50e75a38c9a7370ddbeefabdd3d3116b9c31ef94dc92c6729bc36bec/psutil-7.1.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad81425efc5e75da3f39b3e636293360ad8d0b49bed7df824c79764fb4ba9b8b", size = 240369, upload-time = "2025-11-02T12:26:14.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bd/313aba97cb5bfb26916dc29cf0646cbe4dd6a89ca69e8c6edce654876d39/psutil-7.1.3-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f33a3702e167783a9213db10ad29650ebf383946e91bc77f28a5eb083496bc9", size = 288210, upload-time = "2025-11-02T12:26:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/fa/76e3c06e760927a0cfb5705eb38164254de34e9bd86db656d4dbaa228b04/psutil-7.1.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f", size = 291182, upload-time = "2025-11-02T12:26:18.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1d/5774a91607035ee5078b8fd747686ebec28a962f178712de100d00b78a32/psutil-7.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:3792983e23b69843aea49c8f5b8f115572c5ab64c153bada5270086a2123c7e7", size = 250466, upload-time = "2025-11-02T12:26:21.183Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/e426584bacb43a5cb1ac91fae1937f478cd8fbe5e4ff96574e698a2c77cd/psutil-7.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:31d77fcedb7529f27bb3a0472bea9334349f9a04160e8e6e5020f22c59893264", size = 245756, upload-time = "2025-11-02T12:26:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/94/46b9154a800253e7ecff5aaacdf8ebf43db99de4a2dfa18575b02548654e/psutil-7.1.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2bdbcd0e58ca14996a42adf3621a6244f1bb2e2e528886959c72cf1e326677ab", size = 238359, upload-time = "2025-11-02T12:26:25.284Z" },
+    { url = "https://files.pythonhosted.org/packages/68/3a/9f93cff5c025029a36d9a92fef47220ab4692ee7f2be0fba9f92813d0cb8/psutil-7.1.3-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc31fa00f1fbc3c3802141eede66f3a2d51d89716a194bf2cd6fc68310a19880", size = 239171, upload-time = "2025-11-02T12:26:27.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b1/5f49af514f76431ba4eea935b8ad3725cdeb397e9245ab919dbc1d1dc20f/psutil-7.1.3-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb428f9f05c1225a558f53e30ccbad9930b11c3fc206836242de1091d3e7dd3", size = 263261, upload-time = "2025-11-02T12:26:29.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1100,15 +1166,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff", size = 1117912, upload-time = "2022-01-07T22:05:58.665Z" },
     { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543", size = 204624, upload-time = "2022-01-07T22:06:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93", size = 212141, upload-time = "2022-01-07T22:06:01.861Z" },
-]
-
-[[package]]
-name = "pyproject-hooks"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
@@ -1160,15 +1217,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,20 +1261,6 @@ wheels = [
 ]
 
 [[package]]
-name = "readme-renderer"
-version = "44.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "nh3" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1242,24 +1276,12 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
+name = "requestsexceptions"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/61b9652d3256503c99b0b8f145d9c8aa24c514caff6efc229989505937c1/requestsexceptions-1.4.0.tar.gz", hash = "sha256:b095cbc77618f066d459a02b137b020c37da9f46d9b057704019c9f77dba3065", size = 6880, upload-time = "2018-02-01T17:04:45.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
-]
-
-[[package]]
-name = "rfc3986"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/49ca60ea8c907260da4662582c434bec98716177674e88df3fd340acf06d/requestsexceptions-1.4.0-py2.py3-none-any.whl", hash = "sha256:3083d872b6e07dc5c323563ef37671d992214ad9a32b0ca4a3d7f5500bf38ce3", size = 3802, upload-time = "2018-02-01T17:04:39.07Z" },
 ]
 
 [[package]]
@@ -1372,19 +1394,6 @@ wheels = [
 ]
 
 [[package]]
-name = "secretstorage"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1428,6 +1437,24 @@ wheels = [
 ]
 
 [[package]]
+name = "stevedore"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1464,26 +1491,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
-name = "twine"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "id" },
-    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
-    { name = "packaging" },
-    { name = "readme-renderer" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "rfc3986" },
-    { name = "rich" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404, upload-time = "2025-01-21T18:45:26.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791, upload-time = "2025-01-21T18:45:24.584Z" },
 ]
 
 [[package]]
@@ -1525,13 +1532,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.21.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545, upload-time = "2024-11-10T15:05:20.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630, upload-time = "2024-11-10T15:05:19.275Z" },
 ]


### PR DESCRIPTION
Also, I'm now using `uv version --bump patch` for this. While it doesn't capture the example settings file, that's not a big deal.