### PR TITLE
feat: treat uv.lock as binary and configure merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+uv.lock binary merge=uv-lock

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Copy the example settings file to `broker_settings.yaml` and edit it.
 
 To run Broker outside of its base directory, specify the directory with the `BROKER_DIRECTORY` environment variable.
 
+### Handling uv.lock conflicts
+
+This project treats `uv.lock` as a binary file to suppress large diffs. To automatically resolve conflicts in this file, you can configure a custom merge driver:
+
+```bash
+git config merge.uv-lock.name "Generate uv.lock"
+git config merge.uv-lock.driver "uv lock"
+```
+
 
 # API Usage
 TODO: Flesh this out


### PR DESCRIPTION
This marks uv.lock as a binary file to suppress diffs and configures a custom merge driver 'uv-lock' to automatically regenerate the lockfile on conflicts.

Instructions for configuring the local git merge driver have been added to README.md.