### PR TITLE
Fix _merge_artifacts strategy defaulting for None

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -430,7 +430,7 @@ class AnsibleTower(Provider):
                 message=f"Ambiguous AnsibleTower inventory {inventory} passed from {caller_context}",
             )
 
-    def _merge_artifacts(self, at_object, strategy="last", artifacts=None):
+    def _merge_artifacts(self, at_object, strategy=None, artifacts=None):
         """Gather and merge all artifacts associated with an object and its children.
 
         :param at_object: object you want to merge
@@ -445,6 +445,8 @@ class AnsibleTower(Provider):
         :return: dictionary of merged artifact, used for constructing host
         """
         logger.debug(f"Attempting to merge: {at_object.name}")
+        if strategy is None:
+            strategy = "last"
 
         if artifacts is None:
             artifacts = {}


### PR DESCRIPTION
Fixes:
Corrected the handling of the `strategy` parameter in the `_merge_artifacts` method. The default value for the `strategy` parameter in the function signature was changed from `"last"` to `None`. An explicit check was added within the method to set `strategy` to `"last"` if its value is `None`. This ensures that explicitly passing `None` for the `strategy` parameter now correctly resolves to the `"last"` merge strategy, preventing unintended behavior where `None` would override the desired default.