### PR TITLE
Disable Dependabot updates for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+
+  # Python dependencies - managed manually with uv
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Configuration:
- Add a new `package-ecosystem` entry for `pip` to `.github/dependabot.yml`.
- Set `open-pull-requests-limit` to `0` for Python dependencies.
- This change prevents Dependabot from automatically creating pull requests for Python dependency updates, as these are now managed manually using `uv`.