### PR TITLE
Update AnsibleTower extend signature to handle extra keyword arguments

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -912,7 +912,7 @@ class AnsibleTower(Provider):
         ]
         return compiled_host_info
 
-    def extend(self, target_vm, new_expire_time=None, provider_labels=None):
+    def extend(self, target_vm, new_expire_time=None, provider_labels=None, **trash):
         """Run the extend workflow with defaults args.
 
         :param target_vm: This should be a host object


### PR DESCRIPTION
Refactoring:
- Modify the extend method in the AnsibleTower provider to accept arbitrary keyword arguments via **trash. This ensures compatibility with higher-level broker calls that may pass more information than the method requires, preventing potential signature mismatch errors.