### PR TITLE
Fix UnboundLocalError in AnsibleTower provider due to lazy-loaded artifacts

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -482,6 +482,7 @@ class AnsibleTower(Provider):
                     child_obj = self._v2.jobs.get(id=child_id).results
                     if child_obj:
                         child_obj = child_obj.pop()
+                        child_obj = child_obj.get()  # Hydrate job object with artifacts
                         artifacts = (
                             self._merge_artifacts(child_obj, strategy, artifacts) or artifacts
                         )
@@ -511,6 +512,7 @@ class AnsibleTower(Provider):
                     child_obj = self._v2.jobs.get(id=child_id).results
                     if child_obj:
                         child_obj = child_obj.pop()
+                        child_obj = child_obj.get()  # Hydrate job with full error details
                         if child_obj.status == "error":
                             failure_messages.append(
                                 {
@@ -559,7 +561,8 @@ class AnsibleTower(Provider):
             ):  # skip jobs with no summary fields and failed jobs
                 continue
             if jobs := self._v2.jobs.get(id=job_fields["id"]).results:
-                if vm_name := jobs[0].artifacts.get("vm_name"):
+                job = jobs[0].get()  # Hydrate job with artifacts
+                if vm_name := job.artifacts.get("vm_name"):
                     hosts.append(vm_name)
         return list(set(hosts))
 


### PR DESCRIPTION
After upgrading to AAP 4.6.20, awxkit's lazy-loading behavior prevents
artifacts from being populated when job objects are fetched via
.jobs.get(id=X).results. The artifacts only appear after explicitly
calling .get() on the individual job object.

This caused construct_host() to fail with UnboundLocalError because
artifacts were empty, preventing host_inst from being created.

Changes:
- _merge_artifacts(): Add .get() call after .pop() to hydrate job with artifacts (line 485)
- _get_failure_messages(): Add .get() call to load full error details (line 515)
- _try_get_dangling_hosts(): Add .get() call to hydrate job before accessing artifacts (line 564)

Impact:
- Fixes host checkout failures on AAP 4.6.20+
- Ensures proper error message retrieval from failed jobs
- Enables finding dangling hosts after workflow failures

Testing:
- All existing unit tests pass (11/11)
- Pre-commit checks pass
- Verified working with live AAP 4.6.20 instance

Resolves: https://github.com/SatelliteQE/broker/issues/471

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
