### PR TITLE
Fix CLI passthrough args: split only on first '='

### DIFF
--- a/broker/helpers/misc.py
+++ b/broker/helpers/misc.py
@@ -37,12 +37,25 @@ def resolve_nick(nick, broker_settings=None):
 
 def kwargs_from_click_ctx(ctx):
     """Convert a Click context object to a dictionary of keyword arguments."""
-    # If users use `--opt=value`, split only on the first `=`. Do not split bare
-    # `key=value` tokens: those are often values for a preceding `--opt` when the
-    # value itself contains `=` (see broker#488).
+    # Normalize `--opt value`, `--opt=value`, and naked `key=value` into a flat
+    # [key, value, ...] list. Split only the first `=` per token.
+    #
+    # If the previous token was `--opt` without `=`, the next token is always the
+    # full value (even if it looks like `a=b`); see broker#488.
     _args = []
+    pending_value = False
     for arg in ctx.args:
+        if pending_value:
+            _args.append(arg)
+            pending_value = False
+            continue
         if arg.startswith("-") and "=" in arg:
+            key, value = arg.split("=", 1)
+            _args.extend([key, value])
+        elif arg.startswith("-") and "=" not in arg:
+            _args.append(arg)
+            pending_value = True
+        elif "=" in arg:
             key, value = arg.split("=", 1)
             _args.extend([key, value])
         else:

--- a/broker/helpers/misc.py
+++ b/broker/helpers/misc.py
@@ -37,10 +37,12 @@ def resolve_nick(nick, broker_settings=None):
 
 def kwargs_from_click_ctx(ctx):
     """Convert a Click context object to a dictionary of keyword arguments."""
-    # if users use `=` to note arg=value assignment, then we need to split it
+    # If users use `--opt=value`, split only on the first `=`. Do not split bare
+    # `key=value` tokens: those are often values for a preceding `--opt` when the
+    # value itself contains `=` (see broker#488).
     _args = []
     for arg in ctx.args:
-        if "=" in arg:
+        if arg.startswith("-") and "=" in arg:
             key, value = arg.split("=", 1)
             _args.extend([key, value])
         else:

--- a/broker/helpers/misc.py
+++ b/broker/helpers/misc.py
@@ -41,7 +41,8 @@ def kwargs_from_click_ctx(ctx):
     _args = []
     for arg in ctx.args:
         if "=" in arg:
-            _args.extend(arg.split("="))
+            key, value = arg.split("=", 1)
+            _args.extend([key, value])
         else:
             _args.append(arg)
     ctx.args = _args

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -222,6 +222,24 @@ def test_kwargs_from_click_ctx_preserves_equals_in_spaced_value():
     assert kwargs == {"deploy_foreman_development_extra_vars": extra}
 
 
+def test_kwargs_from_click_ctx_naked_key_value():
+    """Leading-dash-less key=value pairs (foo=bar) are split into keys and values."""
+    class ctx:
+        args = ["foo=bar", "baz=qux"]
+
+    kwargs = helpers.kwargs_from_click_ctx(ctx)
+    assert kwargs == {"foo": "bar", "baz": "qux"}
+
+
+def test_kwargs_from_click_ctx_mixed_dashed_and_naked():
+    """Naked k=v pairs can follow dashed --opt value pairs."""
+    class ctx:
+        args = ["--a", "1", "foo=bar"]
+
+    kwargs = helpers.kwargs_from_click_ctx(ctx)
+    assert kwargs == {"a": "1", "foo": "bar"}
+
+
 def test_resolve_nick_raises_error_for_unknown_nick():
     """Test that resolve_nick raises UserError for a non-existent nick."""
     with pytest.raises(exceptions.UserError, match=r"Unknown nick: nothere"):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -196,6 +196,19 @@ def test_kwargs_from_click_ctx():
     assert kwargs == {"arg1": "value1", "arg2": "value2"}
 
 
+def test_kwargs_from_click_ctx_preserves_equals_in_value():
+    """Values with '=' (e.g. extra_vars) must stay one string; see SatelliteQE/broker#488."""
+    extra = (
+        "deploy_git_repository_remote_name=upstream,"
+        "deploy_git_repository_secondary_remote_name=origin"
+    )
+    class ctx:
+        args = [f"--deploy_foreman_development_extra_vars={extra}"]
+
+    kwargs = helpers.kwargs_from_click_ctx(ctx)
+    assert kwargs == {"deploy_foreman_development_extra_vars": extra}
+
+
 def test_resolve_nick_raises_error_for_unknown_nick():
     """Test that resolve_nick raises UserError for a non-existent nick."""
     with pytest.raises(exceptions.UserError, match=r"Unknown nick: nothere"):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -209,6 +209,19 @@ def test_kwargs_from_click_ctx_preserves_equals_in_value():
     assert kwargs == {"deploy_foreman_development_extra_vars": extra}
 
 
+def test_kwargs_from_click_ctx_preserves_equals_in_spaced_value():
+    """Space-separated --opt VALUE form; VALUE may contain '=' and must not be split."""
+    extra = (
+        "deploy_git_repository_remote_name=upstream,"
+        "deploy_git_repository_secondary_remote_name=origin"
+    )
+    class ctx:
+        args = ["--deploy_foreman_development_extra_vars", extra]
+
+    kwargs = helpers.kwargs_from_click_ctx(ctx)
+    assert kwargs == {"deploy_foreman_development_extra_vars": extra}
+
+
 def test_resolve_nick_raises_error_for_unknown_nick():
     """Test that resolve_nick raises UserError for a non-existent nick."""
     with pytest.raises(exceptions.UserError, match=r"Unknown nick: nothere"):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,6 +13,12 @@ BROKER_ARGS_DATA = {
     "my_second_arg": "foo",
 }
 
+# Shared by kwargs_from_click_ctx tests: value contains '=' and must not be split (SatelliteQE/broker#488).
+_EXTRA_VARS_WITH_EQUALS = (
+    "deploy_git_repository_remote_name=upstream,"
+    "deploy_git_repository_secondary_remote_name=origin"
+)
+
 
 @pytest.fixture
 def tmp_file(tmp_path):
@@ -198,28 +204,20 @@ def test_kwargs_from_click_ctx():
 
 def test_kwargs_from_click_ctx_preserves_equals_in_value():
     """Values with '=' (e.g. extra_vars) must stay one string; see SatelliteQE/broker#488."""
-    extra = (
-        "deploy_git_repository_remote_name=upstream,"
-        "deploy_git_repository_secondary_remote_name=origin"
-    )
     class ctx:
-        args = [f"--deploy_foreman_development_extra_vars={extra}"]
+        args = [f"--deploy_foreman_development_extra_vars={_EXTRA_VARS_WITH_EQUALS}"]
 
     kwargs = helpers.kwargs_from_click_ctx(ctx)
-    assert kwargs == {"deploy_foreman_development_extra_vars": extra}
+    assert kwargs == {"deploy_foreman_development_extra_vars": _EXTRA_VARS_WITH_EQUALS}
 
 
 def test_kwargs_from_click_ctx_preserves_equals_in_spaced_value():
     """Space-separated --opt VALUE form; VALUE may contain '=' and must not be split."""
-    extra = (
-        "deploy_git_repository_remote_name=upstream,"
-        "deploy_git_repository_secondary_remote_name=origin"
-    )
     class ctx:
-        args = ["--deploy_foreman_development_extra_vars", extra]
+        args = ["--deploy_foreman_development_extra_vars", _EXTRA_VARS_WITH_EQUALS]
 
     kwargs = helpers.kwargs_from_click_ctx(ctx)
-    assert kwargs == {"deploy_foreman_development_extra_vars": extra}
+    assert kwargs == {"deploy_foreman_development_extra_vars": _EXTRA_VARS_WITH_EQUALS}
 
 
 def test_kwargs_from_click_ctx_naked_key_value():


### PR DESCRIPTION
kwargs_from_click_ctx used split('=') which broke values containing '='. Use split('=', 1) so deploy_foreman_development_extra_vars and similar options pass through intact (fixes #488).

Add regression test.

Made-with: Cursor