### PR TITLE
Change deprecated pythonjsonlogger.jsonlogger import to pythonjsonlogger.json

### DIFF
--- a/broker/logging.py
+++ b/broker/logging.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 
 import click
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import json
 from rich.logging import RichHandler
 
 from broker.settings import BROKER_DIRECTORY
@@ -207,7 +207,7 @@ def setup_logging(
 
             # JSON structured logging
             json_file_handler.setFormatter(
-                jsonlogger.JsonFormatter(
+                json.JsonFormatter(
                     "%(asctime)s %(name)s %(levelname)s %(message)s",
                     rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
                     datefmt="%d%b %H:%M:%S",


### PR DESCRIPTION
The `jsonlogger` module was deprecated a long time ago:

https://nhairs.github.io/python-json-logger/latest/changelog/#310-2023-05-28
https://nhairs.github.io/python-json-logger/latest/changelog/#changed_2

This PR updates the import in logging.py, resolving these warnings in robottelo:

```
$ pytest tests/foreman/api/test_activationkey.py::test_positive_update_auto_attach
[...]
../../Python/venv_robottelo/lib64/python3.12/site-packages/pythonjsonlogger/jsonlogger.py:11
  /home/tpapaioa/Python/venv_robottelo/lib64/python3.12/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=== 1 passed, 1 warning in 13.91s ===
```