### PR TITLE
Only check for dangling hosts in workflow jobs

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -567,6 +567,9 @@ class AnsibleTower(Provider):
     def _try_get_dangling_hosts(self, failed_workflow):
         """Get one or more hosts that may have been left behind by a failed workflow."""
         hosts = []
+        # Avoid assertion errors looking up workflow nodes if this isn't a workflow job
+        if "workflow_nodes" not in failed_workflow.related:
+            return hosts
         for node in failed_workflow.get_related("workflow_nodes").results:
             if not (job_fields := node.summary_fields.get("job", {})) or job_fields.get(
                 "failed"


### PR DESCRIPTION
If a failed AAP job is not a workflow job, but a regular job template-based job, broker triggers an `AssertionError` when trying to get the job's non-existent `"workflow_nodes"`. The resulting error output masks the original error. For example, when trying to run Satellite upgrade tests, which call the non-workflow-based job template `satellite-upgrade`:

```
$ pytest tests/new_upgrades/test_bookmarks.py::test_post_disabled_bookmark
[...]
02:11:10  tests/new_upgrades/conftest.py:115: in _upgrade_action
02:11:10      ).execute()
02:11:10        ^^^^^^^^^
02:11:10  ../../lib64/python3.12/site-packages/broker/broker.py:175: in execute
02:11:10      return self._act(provider, method)
02:11:10             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
02:11:10  ../../lib64/python3.12/site-packages/broker/broker.py:112: in _act
02:11:10      result.append(task.result())
02:11:10                    ^^^^^^^^^^^^^
[...]
02:11:10  ../../lib64/python3.12/site-packages/broker/providers/ansible_tower.py:902: in execute
02:11:10      self.handle_dangling_hosts(
02:11:10  ../../lib64/python3.12/site-packages/broker/providers/ansible_tower.py:583: in handle_dangling_hosts
02:11:10      dangling_hosts = self._try_get_dangling_hosts(job)
02:11:10                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
02:11:10  ../../lib64/python3.12/site-packages/broker/providers/ansible_tower.py:570: in _try_get_dangling_hosts
02:11:10      for node in failed_workflow.get_related("workflow_nodes").results:
02:11:10                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
02:11:10  ../../lib64/python3.12/site-packages/awxkit/api/pages/page.py:291: in get_related
02:11:10      assert related_name in self.json.get('related', [])
02:11:10             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
02:11:10  E   AssertionError
```

This PR updates the "dangling hosts" check to run only for workflow jobs.