### PR TITLE
Get failure_message from non-workflow based AAP jobs

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -555,6 +555,15 @@ class AnsibleTower(Provider):
                                 if ev.event_data.get("res", {}).get("msg")
                             ]
                         )
+        else:
+            # Get name and output directly from non-workflow job
+            failure_messages.append(
+                {
+                    "job": workflow.name,
+                    "reason": workflow.result_stdout,
+                }
+            )
+
         if not failure_messages:
             return {
                 "reason": f"Unable to determine failure cause for {workflow.name} at {workflow.url}"


### PR DESCRIPTION
If broker runs an AAP job template instead of a workflow, and the job fails, then broker doesn't get any output from the job. This PR updates `_get_failure_messages` to get the output from a failed non-workflow job as well.

Unlike workflow nodes, the job doesn't have `result_traceback` or `job_events` to read from -- for these jobs we just read the `result_stdout` and return that.

For example, from a failed `satellite-upgrade` JT job:

```
E           AnsibleTower encountered the following error: {
E             "job": "satellite-upgrade",
E             "reason": "Identity added: /runner/artifacts/4329384/ssh_key_data (/runner/artifacts/4329384/ssh_key_data)\nVault password (user): \n[WARNING]: Invalid characters were found in group names but not replaced, use\n-vvvv to see details\n\nPLAY [tpapaioa-test-vm] *************************\n\nTASK [Gathering Facts]  [SNIP] \nTuesday 28 April 2026  18:49:59 +0000 (0:00:00.152)       0:00:48.943 ********* \nfatal: [tpapaioa-test-vm]: FAILED! => {\"changed\": false, \"dest\": \"/etc/yum.repos.d/satellite.repo\", \"elapsed\": 0, \"gid\": 0, \"group\": \"root\", \"mode\": \"0644\", \"msg\": \"Request failed\", \"owner\": \"root\", \"response\": \"HTTP Error 500: Internal Server Error\", \"secontext\": \"system_u:object_r:system_conf_t:s0\", \"size\": 698, \"state\": \"file\", \"status_code\": 500, \"uid\": 0, \"url\": \"https://repo.example.com/api/releases/bloh/el9/satellite/repo_file\"}\n\nPLAY RECAP *********************************************************************\ntpapaioa-test-vm : ok=14   changed=1    unreachable=0    failed=1    skipped=4    rescued=0    ignored=0   \nPlaybook run took 0 days, 0 hours, 0 minutes, 49 seconds\nTuesday 28 April 2026  18:50:00 +0000 (0:00:00.646)       0:00:49.589 ********* [SNIP]
E           }

tests/new_upgrades/conftest.py:128: SatelliteHostError
```