### PR TITLE
Add workflow_poll_interval setting to override default AWX value

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -111,15 +111,17 @@ def convert_pseudonamespaces(attr_dict):
     return out_dict
 
 
-def resilient_job_wait(job, broker_settings, job_timeout=None, max_wait=None):
+def resilient_job_wait(job, broker_settings, job_interval=None, job_timeout=None, max_wait=None):
     """Wait for a job to complete. Retry on errors.
 
     Args:
         job: The job object to wait for
         broker_settings: Settings object to use instead of the global one
+        job_interval: Interval between job status polls
         job_timeout: Timeout for individual job wait attempts
         max_wait: Maximum time to continue retrying before giving up
     """
+    job_interval = job_interval or broker_settings.ANSIBLETOWER.workflow_poll_interval
     job_timeout = job_timeout or broker_settings.ANSIBLETOWER.workflow_timeout
     max_wait = max_wait or broker_settings.ANSIBLETOWER.max_resilient_wait
     completed = False
@@ -137,7 +139,7 @@ def resilient_job_wait(job, broker_settings, job_timeout=None, max_wait=None):
             )
 
         try:
-            job.wait_until_completed(timeout=job_timeout)
+            job.wait_until_completed(interval=job_interval, timeout=job_timeout)
             completed = True
         except (ConnectionError, awxkit.exceptions.Unknown, awxkit.exceptions.Forbidden) as err:
             logger.error(f"Error occurred while waiting for job: {err}")
@@ -267,6 +269,7 @@ class AnsibleTower(Provider):
         Validator("ANSIBLETOWER.extend_workflow", default="extend-vm"),
         Validator("ANSIBLETOWER.new_expire_time", default="+172800"),
         Validator("ANSIBLETOWER.workflow_timeout", is_type_of=int, default=3600),
+        Validator("ANSIBLETOWER.workflow_poll_interval", is_type_of=int, default=5),
         Validator("ANSIBLETOWER.results_limit", is_type_of=int, default=20),
         Validator("ANSIBLETOWER.error_scope", default="last"),
         Validator("ANSIBLETOWER.base_url", must_exist=True),

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -44,6 +44,7 @@ AnsibleTower:
     extend_workflow: "extend-vm"
     new_expire_time: "+172800"
     workflow_timeout: 3600
+    workflow_poll_interval: 5
     max_resilient_wait: 7200
     results_limit: 50
 Container:


### PR DESCRIPTION
The default polling interval for AAP jobs in awxkit is 5 seconds, which results in a lot of unnecessary polling and logging when executing long-running jobs like Satellite deployments or upgrades. This PR adds the ability to override this default value, with the new `workflow_poll_interval` setting for `AnsibleTower` providers:

```
$ broker config view AnsibleTower.workflow_poll_interval
30

$ tail -f logs/robottelo.log

2026-05-29 16:04:13 - broker.providers.ansible_tower - INFO - Waiting for job: 
    API: https://aap.example.com/api/controller/v2/workflow_jobs/417/
    UI: https://aap.example.com/execution/jobs/workflow/417/output
2026-05-29 16:04:13 - urllib3.connectionpool - DEBUG - https://aap.example.com:443 "GET /api/controller/v2/workflow_jobs/417/ HTTP/1.1" 200 None
2026-05-29 16:04:43 - urllib3.connectionpool - DEBUG - https://aap.example.com:443 "GET /api/controller/v2/workflow_jobs/417/ HTTP/1.1" 200 None
2026-05-29 16:05:13 - urllib3.connectionpool - DEBUG - https://aap.example.com:443 "GET /api/controller/v2/workflow_jobs/417/ HTTP/1.1" 200 None
2026-05-29 16:05:43 - urllib3.connectionpool - DEBUG - https://aap.example.com:443 "GET /api/controller/v2/workflow_jobs/417/ HTTP/1.1" 200 None
2026-05-29 16:06:13 - urllib3.connectionpool - DEBUG - https://aap.example.com:443 "GET /api/controller/v2/workflow_jobs/417/ HTTP/1.1" 200 None
```