### PR TITLE
Fix file write race conditions and add humanized timestamp display

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -378,7 +378,8 @@ def inventory(details, _list, sync, filter):
     helpers.emit({"inventory": inventory})
     # details is handled differently than the normal and list views
     if details:
-        detailed = helpers.yaml_format(dict(enumerate(inventory)))
+        humanized = [helpers.humanize_inventory_times(host) for host in inventory]
+        detailed = helpers.yaml_format(dict(enumerate(humanized)))
         CONSOLE.print(Syntax(detailed, "yaml", background_color="default"))
         return
 

--- a/broker/config_manager.py
+++ b/broker/config_manager.py
@@ -47,12 +47,16 @@ class ConfigManager:
     no_global_config = False
 
     def __init__(self, settings_path=None):
+        from broker.helpers.file_utils import FileLock
+
         self._settings_path = settings_path
         if settings_path:
             if settings_path.exists():
-                self._cfg = yaml.load(self._settings_path)
+                with FileLock(self._settings_path):
+                    self._cfg = yaml.load(self._settings_path) or {}
             elif self.no_global_config or os.environ.get("BROKER_NO_GLOBAL_CONFIG"):
                 logger.info("Continuing without global config file.")
+                self._cfg = {}
                 return
             else:
                 click.secho(
@@ -109,6 +113,10 @@ class ConfigManager:
         """Construct a list of all applicable migrations."""
         from broker import config_migrations
 
+        # Guard against None config (can happen if file read during write)
+        if self._cfg is None:
+            return []
+
         config_version = Version(self._cfg.get("_version", "0.0.0"))
         if force_version:
             force_version = Version(force_version)
@@ -125,20 +133,29 @@ class ConfigManager:
 
     def backup(self):
         """Backup the current configuration file."""
+        from broker.helpers.file_utils import FileLock
+
         logger.debug(
             f"Backing up the configuration file to {self._settings_path.with_suffix('.bak')}"
         )
-        self._settings_path.with_suffix(".bak").write_text(self._settings_path.read_text())
+        with FileLock(self._settings_path):
+            self._settings_path.with_suffix(".bak").write_text(self._settings_path.read_text())
 
     def restore(self):
         """Restore the configuration file from a backup if it exists."""
+        from broker.helpers.file_utils import FileLock
+
         logger.debug(
             f"Restoring the configuration file from {self._settings_path.with_suffix('.bak')}"
         )
         backup_path = self._settings_path.with_suffix(".bak")
         if not backup_path.exists():
             raise exceptions.UserError("No backup file found.")
-        self._settings_path.write_text(backup_path.read_text())
+
+        with FileLock(self._settings_path):
+            self._settings_path.write_text(backup_path.read_text())
+            # Reload the config
+            self._cfg = yaml.load(self._settings_path) or {}
 
     def edit(self, chunk=None, content=None):
         """Open the config file in an editor."""
@@ -182,6 +199,8 @@ class ConfigManager:
 
     def update(self, chunk, new_val, curr_chunk=None):
         """Update a chunk of Broker's config or the whole config."""
+        from broker.helpers.file_utils import FileLock
+
         # Recursive down to find the chunk to update, then propagate the new value back up
         if not curr_chunk:  # we're at the top level, so update the config directly
             if chunk is None:  # the whole config is being updated
@@ -194,7 +213,9 @@ class ConfigManager:
             # update the config file if it exists
             if self._settings_path.exists():
                 self.backup()
-            yaml.dump(self._cfg, self._settings_path)
+
+            with FileLock(self._settings_path):
+                yaml.dump(self._cfg, self._settings_path)
         else:  # we're not at the top level, so keep going down
             if C_SEP in chunk:
                 curr, chunk = chunk.split(C_SEP, 1)
@@ -251,17 +272,25 @@ class ConfigManager:
 
     def migrate(self, force_version=None):
         """Migrate the config from a previous version of Broker."""
-        # get all available migrations
-        if not (migrations := self._get_migrations(force_version)):
-            logger.info("No migrations are applicable to your config.")
-            return
-        # run all migrations in order
-        working_config = self._cfg
-        for migration in sorted(migrations, key=lambda m: m.TO_VERSION):
-            working_config = migration.run_migrations(working_config)
-        self.backup()
-        yaml.dump(working_config, self._settings_path)
-        logger.info("Config migration complete.")
+        from broker.helpers.file_utils import FileLock
+
+        with FileLock(self._settings_path):
+            # Re-read config under lock to check if already migrated
+            self._cfg = yaml.load(self._settings_path) or {}
+
+            # get all available migrations
+            if not (migrations := self._get_migrations(force_version)):
+                logger.info("No migrations are applicable to your config.")
+                return
+            # run all migrations in order
+            working_config = self._cfg
+            for migration in sorted(migrations, key=lambda m: m.TO_VERSION):
+                working_config = migration.run_migrations(working_config)
+            self.backup()
+            yaml.dump(working_config, self._settings_path)
+            # Update in-memory config
+            self._cfg = working_config
+            logger.info("Config migration complete.")
 
     def validate(self, chunk, providers):
         """Validate a top-level chunk of Broker's config."""

--- a/broker/helpers/__init__.py
+++ b/broker/helpers/__init__.py
@@ -39,10 +39,10 @@ from broker.helpers.git import (
 
 # Inventory utilities
 from broker.helpers.inventory import (
-    INVENTORY_LOCK,
     SPECIAL_INVENTORY_FIELDS,
     flip_provider_actions,
     get_host_action,
+    humanize_inventory_times,
     inventory_fields_to_dict,
     load_inventory,
     update_inventory,
@@ -56,6 +56,7 @@ from broker.helpers.misc import (
     emit,
     find_origin,
     fork_broker,
+    format_host_time_value,
     handle_keyboardinterrupt,
     kwargs_from_click_ctx,
     resolve_nick,
@@ -74,7 +75,6 @@ from broker.helpers.results import (
 )
 
 __all__ = [
-    "INVENTORY_LOCK",
     "SPECIAL_INVENTORY_FIELDS",
     "Emitter",
     "FileLock",
@@ -95,8 +95,10 @@ __all__ = [
     "flatten_dict",
     "flip_provider_actions",
     "fork_broker",
+    "format_host_time_value",
     "get_host_action",
     "handle_keyboardinterrupt",
+    "humanize_inventory_times",
     "inventory_fields_to_dict",
     "kwargs_from_click_ctx",
     "load_file",

--- a/broker/helpers/file_utils.py
+++ b/broker/helpers/file_utils.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 import random
 import tarfile
+import threading
 import time
 from uuid import uuid4
 
@@ -154,7 +155,7 @@ def yaml_format(in_struct, force_yaml_dict=False):
 
 
 class FileLock:
-    """Basic file locking class that acquires and releases locks.
+    """File locking class with both inter-process and intra-process protection.
 
     Recommended usage is the context manager which will handle everything for you
 
@@ -169,12 +170,38 @@ class FileLock:
 
     with FileLock("basic_file.txt", timeout=20, delay_start=True):
         Path("basic_file.txt").write_text("some text")
+
+    This implementation provides:
+    - Inter-process locking via .lock files (for pytest-xdist, concurrent CLI)
+    - Intra-process locking via threading.RLock (reentrant, allows nested locks by same thread)
+    - Acquisition counting to support nested locks from the same thread
+    - Optional random jitter to reduce lock contention when many processes start simultaneously
     """
 
+    # Class-level dict mapping file paths to threading locks
+    # This ensures all FileLock instances for the same file share the same thread lock
+    _thread_locks = {}
+    _thread_locks_lock = threading.Lock()  # Protects _thread_locks dict itself
+
+    # Class-level dict to track acquisition count per thread per file
+    # Format: {(thread_id, lock_key): count}
+    _acquisition_counts = {}
+
     def __init__(self, file_name, timeout=10, delay_start=False):
-        self.lock = Path(f"{file_name}.lock")
+        self.file_name = Path(file_name)
         self.timeout = timeout
         self.delay_start = delay_start
+
+        # Get or create a thread lock for this file path
+        # Use the normalized absolute path as the key to ensure consistency
+        # Use RLock (reentrant) to allow the same thread to acquire multiple times (nested locks)
+        # Also use the resolved path for the lock file to ensure all callers coordinate on the same lock
+        self.lock_key = str(self.file_name.resolve())
+        self.lock = Path(f"{self.lock_key}.lock")
+        with self._thread_locks_lock:
+            if self.lock_key not in self._thread_locks:
+                self._thread_locks[self.lock_key] = threading.RLock()
+            self._thread_lock = self._thread_locks[self.lock_key]
 
     def wait_file(self, timeout=None, delay_start=None):
         """Wait for the lock file to be released, then acquire it atomically."""
@@ -196,13 +223,57 @@ class FileLock:
 
     def return_file(self):
         """Release the lock file."""
-        self.lock.unlink()
+        with contextlib.suppress(FileNotFoundError):
+            self.lock.unlink()
 
     def __enter__(self):  # noqa: D105
-        self.wait_file()
+        # Acquire thread lock first (intra-process)
+        self._thread_lock.acquire()
+
+        # Track acquisition count for this thread
+        thread_id = threading.get_ident()
+        count_key = (thread_id, self.lock_key)
+
+        with self._thread_locks_lock:
+            count = self._acquisition_counts.get(count_key, 0)
+            self._acquisition_counts[count_key] = count + 1
+
+        try:
+            # Only acquire file lock on first acquisition (not on nested calls)
+            if count == 0:
+                self.wait_file()
+        except Exception:
+            # If file lock fails, decrement count and release thread lock
+            with self._thread_locks_lock:
+                self._acquisition_counts[count_key] -= 1
+                if self._acquisition_counts[count_key] == 0:
+                    del self._acquisition_counts[count_key]
+            self._thread_lock.release()
+            raise
+
+        return self
 
     def __exit__(self, *tb_info):  # noqa: D105
-        self.return_file()
+        thread_id = threading.get_ident()
+        count_key = (thread_id, self.lock_key)
+
+        # Decrement acquisition count
+        with self._thread_locks_lock:
+            count = self._acquisition_counts.get(count_key, 1)
+            count -= 1
+            if count > 0:
+                self._acquisition_counts[count_key] = count
+            elif count_key in self._acquisition_counts:
+                # Last release - clean up count tracker
+                del self._acquisition_counts[count_key]
+
+        try:
+            # Only release file lock on final release (not on nested exits)
+            if count == 0:
+                self.return_file()
+        finally:
+            # Always release thread lock
+            self._thread_lock.release()
 
 
 @contextmanager

--- a/broker/helpers/inventory.py
+++ b/broker/helpers/inventory.py
@@ -1,17 +1,15 @@
 """Inventory management utilities."""
 
-import threading
-
 from ruamel.yaml import YAML
 
 from broker.helpers.dict_utils import dict_from_paths, merge_dicts
 from broker.helpers.file_utils import load_file
+from broker.helpers.misc import format_host_time_value
 
 yaml = YAML()
 yaml.default_flow_style = False
 yaml.sort_keys = False
 
-INVENTORY_LOCK = threading.Lock()
 SPECIAL_INVENTORY_FIELDS = {}  # use the _special_inventory_field decorator to add new fields
 
 
@@ -32,12 +30,14 @@ def load_inventory(filter=None):
 
     :return: list of dictionaries
     """
+    from broker.helpers.file_utils import FileLock
     from broker.helpers.results import eval_filter
     from broker.settings import inventory_path
 
-    inv_data = load_file(inventory_path, warn=False)
-    if inv_data and filter:
-        inv_data = eval_filter(inv_data, filter)
+    with FileLock(inventory_path):
+        inv_data = load_file(inventory_path, warn=False)
+        if inv_data and filter:
+            inv_data = eval_filter(inv_data, filter)
     return inv_data or []
 
 
@@ -49,6 +49,7 @@ def update_inventory(add=None, remove=None):
 
     :return: no return value
     """
+    from broker.helpers.file_utils import FileLock
     from broker.settings import inventory_path
 
     if add and not isinstance(add, list):
@@ -57,9 +58,12 @@ def update_inventory(add=None, remove=None):
         add = []
     if remove and not isinstance(remove, list):
         remove = [remove]
-    with INVENTORY_LOCK:
-        inv_data = load_inventory()
-        if inv_data:
+
+    with FileLock(inventory_path):
+        # Entire read-modify-write cycle under lock
+        inv_data = load_file(inventory_path, warn=False) or []
+
+        if inv_data and inventory_path.exists():
             inventory_path.unlink()
 
         if remove:
@@ -138,7 +142,10 @@ def _resolve_inv_field(field, host_dict, **extras):
     if special_field_func := SPECIAL_INVENTORY_FIELDS.get(field):
         return special_field_func(host_dict, **extras)
     # Otherwise, try to get the value from the host dictionary
-    return dict_from_paths(host_dict, {"_": field}, sep=".")["_"] or "Unknown"
+    result = dict_from_paths(host_dict, {"_": field}, sep=".")["_"]
+    if result is not None and field.endswith("_time"):
+        return format_host_time_value(result)
+    return result or "Unknown"
 
 
 @_special_inventory_field("$action")
@@ -159,3 +166,21 @@ def get_host_action(host_dict, provider_actions=None, **_):
         if action := host_dict["_broker_args"].get(opt):
             return action
     return "Unknown"
+
+
+def humanize_inventory_times(host_dict):
+    """Return a copy of host_dict with all ``*_time`` field values formatted for humans.
+
+    Fields whose names end with ``_time`` and whose values are numeric strings are
+    converted using :func:`format_host_time_value`.  Nested dicts are processed
+    recursively; other values are left unchanged.
+    """
+    result = {}
+    for key, value in host_dict.items():
+        if isinstance(value, dict):
+            result[key] = humanize_inventory_times(value)
+        elif key.endswith("_time") and value is not None:
+            result[key] = format_host_time_value(value)
+        else:
+            result[key] = value
+    return result

--- a/broker/helpers/misc.py
+++ b/broker/helpers/misc.py
@@ -7,7 +7,6 @@ import logging
 import os
 from pathlib import Path
 import sys
-import threading
 import time
 
 import click
@@ -80,8 +79,6 @@ class Emitter:
         helpers.emit({"key": "value", "another": 5})
     """
 
-    EMIT_LOCK = threading.Lock()
-
     def __init__(self, emit_file=None):
         """Can empty init and set the file later."""
         self.file = None
@@ -99,6 +96,8 @@ class Emitter:
 
     def emit_to_file(self, *args, **kwargs):
         """Emit data to the file, keeping existing data in-place."""
+        from broker.helpers.file_utils import FileLock
+
         if not self.file:
             return
         for arg in args:
@@ -108,7 +107,8 @@ class Emitter:
         for key, val in kwargs.items():
             if getattr(val, "json", None):
                 kwargs[key] = val.json
-        with self.EMIT_LOCK:
+
+        with FileLock(self.file):
             curr_data = json.loads(self.file.read_text() or "{}")
             curr_data.update(kwargs)
             self.file.write_text(json.dumps(curr_data, indent=4, sort_keys=True))
@@ -233,6 +233,42 @@ def find_origin():
             return prev or "Unknown fixture", jenkins_url
         prev, _frame = f"{frame.function}:{frame.filename}", frame
     return f"Unknown origin by {getpass.getuser()}", jenkins_url
+
+
+def format_host_time_value(value):
+    """Format a numeric time value to a human-readable string.
+
+    Values in Unix epoch timestamp range (year 2001-2100) are formatted as
+    human-readable dates in UTC. All other numeric values are treated as
+    durations and formatted as days/hours/minutes/seconds.
+    """
+    from datetime import datetime, timezone
+
+    # Unix epoch boundaries: Jan 1 2001 00:00:00 UTC and Jan 1 2100 00:00:00 UTC
+    _EPOCH_MIN = 978307200
+    _EPOCH_MAX = 4102444800
+
+    try:
+        ts = int(value)
+    except (ValueError, TypeError):
+        return str(value)
+    if _EPOCH_MIN <= ts <= _EPOCH_MAX:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%b %d, %Y %H:%M UTC")
+    # Otherwise treat as a duration in seconds
+    days = ts // 86400
+    hours = (ts % 86400) // 3600
+    minutes = (ts % 3600) // 60
+    secs = ts % 60
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if secs and not days:
+        parts.append(f"{secs}s")
+    return " ".join(parts) if parts else f"{ts}s"
 
 
 def dictlist_to_table(dict_list, title=None, _id=False, headers=True):

--- a/broker/scenarios.py
+++ b/broker/scenarios.py
@@ -49,10 +49,13 @@ CURRENT_SCHEMA_VERSION = 1
 
 def load_imports_manifest():
     """Load the imports manifest file."""
-    if not IMPORTS_FILE.exists():
-        return {"schema_version": CURRENT_SCHEMA_VERSION, "imports": []}
+    from broker.helpers.file_utils import FileLock
 
-    data = helpers.load_file(IMPORTS_FILE, warn=False) or {}
+    with FileLock(IMPORTS_FILE):
+        if not IMPORTS_FILE.exists():
+            return {"schema_version": CURRENT_SCHEMA_VERSION, "imports": []}
+
+        data = helpers.load_file(IMPORTS_FILE, warn=False) or {}
 
     # Handle version mismatch
     if data.get("schema_version", 0) > CURRENT_SCHEMA_VERSION:
@@ -66,7 +69,10 @@ def load_imports_manifest():
 
 def save_imports_manifest(data):
     """Save the imports manifest file."""
-    helpers.save_file(IMPORTS_FILE, data)
+    from broker.helpers.file_utils import FileLock
+
+    with FileLock(IMPORTS_FILE):
+        helpers.save_file(IMPORTS_FILE, data)
 
 
 def find_import_entry(manifest, source, ref="master"):
@@ -627,8 +633,11 @@ class ScenarioRunner:
 
     def _load_scenario_inventory(self):
         """Load existing scenario inventory from disk if it exists."""
+        from broker.helpers.file_utils import FileLock
+
         if self.inventory_path.exists():
-            inv_data = helpers.load_file(self.inventory_path, warn=False)
+            with FileLock(self.inventory_path):
+                inv_data = helpers.load_file(self.inventory_path, warn=False)
             if inv_data:
                 # Reconstruct host objects from the inventory data
                 hosts = [self._reconstruct_host_safe(h) for h in inv_data]
@@ -643,10 +652,14 @@ class ScenarioRunner:
 
     def _save_scenario_inventory(self):
         """Save the current scenario inventory to disk."""
+        from broker.helpers.file_utils import FileLock
+
         inv_data = [host.to_dict() for host in self.scenario_inventory]
         self.inventory_path.parent.mkdir(parents=True, exist_ok=True)
-        self.inventory_path.touch()
-        yaml.dump(inv_data, self.inventory_path)
+
+        with FileLock(self.inventory_path):
+            self.inventory_path.touch()
+            yaml.dump(inv_data, self.inventory_path)
 
     def _build_context(self, current_step_name, previous_step_memory):
         """Build the Jinja2 template context for a step.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 from concurrent.futures import ThreadPoolExecutor
 import pytest
+from click.testing import CliRunner
 from broker import helpers
 from broker import exceptions
 
@@ -242,3 +243,37 @@ def test_resolve_nick_raises_error_for_unknown_nick():
     """Test that resolve_nick raises UserError for a non-existent nick."""
     with pytest.raises(exceptions.UserError, match=r"Unknown nick: nothere"):
         helpers.resolve_nick("nothere")
+
+
+_TIME_HOST = {
+    "name": "myhost",
+    "hostname": "myhost.example.com",
+    "shutdown_time": "1779455297",
+    "remove_time": "432000",
+    "_broker_provider": "AnsibleTower",
+    "_broker_args": {},
+}
+
+
+def test_inventory_fields_to_dict_formats_time_fields():
+    """inventory_fields_to_dict auto-formats *_time fields in the table display path."""
+    inventory_fields = {"Host": "hostname", "Shutdown": "shutdown_time", "Remove": "remove_time"}
+    result = helpers.inventory_fields_to_dict(inventory_fields=inventory_fields, host_dict=_TIME_HOST)
+    assert result["Host"] == "myhost.example.com"
+    assert "2026" in result["Shutdown"] and "UTC" in result["Shutdown"]
+    assert result["Remove"] == "5d"
+
+
+def test_inventory_details_formats_time_fields(tmp_path, monkeypatch):
+    """``broker inventory --details`` renders *_time fields in human-readable form."""
+    from broker import settings
+    from broker.commands import cli
+
+    inv_file = tmp_path / "inventory.yaml"
+    helpers.yaml.dump([_TIME_HOST], inv_file)
+    monkeypatch.setattr(settings, "inventory_path", inv_file)
+
+    result = CliRunner().invoke(cli, ["inventory", "--details"])
+    assert result.exit_code == 0, result.output
+    assert "1779455297" not in result.output and "2026" in result.output
+    assert "432000" not in result.output and "5d" in result.output


### PR DESCRIPTION
Addresses concurrent file access issues that caused YAML corruption and crashes when multiple processes (pytest-xdist workers, concurrent CLI commands) accessed shared files simultaneously.

Race condition fixes (Issues #507, #508):

- Enhanced FileLock with dual-layer locking for both inter-process (file-based) and intra-process (threading) protection
- Fixed inventory.yaml race condition by replacing threading.Lock with FileLock in load_inventory() and update_inventory()
- Fixed config file race condition by adding FileLock to all config_manager operations (init, backup, restore, update, migrate)
- Added defensive None-guard in _get_migrations() to prevent crashes during concurrent migrations
- Fixed scenario inventory and imports manifest race conditions with FileLock protection
- Fixed emitter race condition by replacing threading.Lock with FileLock

The enhanced FileLock now maintains a class-level dict of threading locks per file path with full reentrancy support using acquisition counting. This ensures both same-process threads and different processes are properly synchronized, while allowing nested locks from the same thread (e.g., when migrate() calls backup()). Thread locks are acquired before file locks and released after for proper cleanup.

Humanized timestamp display (Issue #395):

- Added humanize_inventory_times() helper function to recursively format all *_time fields in inventory host dictionaries
- Updated inventory_fields_to_dict to auto-format *_time fields
- Modified 'broker inventory --details' to display human-readable timestamps instead of epoch values