### PR TITLE
Fix keyboard interrupt resume logic for interactive prompts

### DIFF
--- a/broker/commands.py
+++ b/broker/commands.py
@@ -84,6 +84,10 @@ def guarded_command(group=None, *cli_args, **cli_kwargs):
                 )
                 helpers.emit(return_code=0)
                 return retval
+            except exceptions.InterruptResumeError:
+                # InterruptResumeError should never escape a retry loop - if it does,
+                # something is wrong. Re-raise to avoid masking the programming error.
+                raise
             except Exception as err:  # noqa: BLE001 -- we want to catch all exceptions
                 if isinstance(err, exceptions.ScenarioError):
                     # Show full message for scenario errors since context is important
@@ -929,9 +933,18 @@ def _handle_ambiguous_names(filtered_scenarios, name, category, import_all):
         for idx, s in enumerate(filtered_scenarios, 1):
             CONSOLE.print(f" {idx}. {s['path']}")
 
-        choice = click.prompt(
-            "Enter the number of the scenario to import (or 0 to cancel)", type=int, default=0
-        )
+        # Retry prompt on keyboard interrupt with resume
+        while True:
+            try:
+                choice = click.prompt(
+                    "Enter the number of the scenario to import (or 0 to cancel)",
+                    type=int,
+                    default=0,
+                )
+                break
+            except exceptions.InterruptResumeError:
+                logger.debug("Prompt interrupted, retrying...")
+                continue
         if choice == 0:
             return filtered_scenarios, filtered_paths, False
         if 1 <= choice <= len(filtered_scenarios):

--- a/broker/config_manager.py
+++ b/broker/config_manager.py
@@ -235,14 +235,19 @@ class ConfigManager:
         """Check for the existence of the config file and create it if it doesn't exist."""
         if self.interactive_mode and self._settings_path.exists() and not chunk:
             # if the file exists, ask the user if they want to overwrite it
-            if (
-                click.prompt(
-                    f"Overwrite the settings file at {self._settings_path.absolute()}. Overwrite?",
-                    type=click.Choice(["y", "n"]),
-                    default="n",
-                )
-                != "y"
-            ):
+            # Retry prompt on keyboard interrupt with resume
+            while True:
+                try:
+                    choice = click.prompt(
+                        f"Overwrite the settings file at {self._settings_path.absolute()}. Overwrite?",
+                        type=click.Choice(["y", "n"]),
+                        default="n",
+                    )
+                    break
+                except exceptions.InterruptResumeError:
+                    logger.debug("Prompt interrupted, retrying...")
+                    continue
+            if choice != "y":
                 return
         raw_data = None
         if _from:

--- a/broker/exceptions.py
+++ b/broker/exceptions.py
@@ -122,3 +122,19 @@ class ScenarioError(BrokerError):
             self.message = message
 
         super().__init__(message=self.message)
+
+
+class InterruptResumeError(Exception):
+    """Raised when a keyboard interrupt is caught and user chooses to resume.
+
+    This is a control-flow exception used to signal that an interactive prompt
+    should be retried after a keyboard interrupt. It must be caught by a retry
+    loop wrapping the prompt - if it escapes to global exception handlers, it
+    indicates a programming error (missing retry loop).
+
+    This is NOT a BrokerError and should not be logged as an error. Global
+    exception handlers should re-raise it rather than converting it to a
+    BrokerError to avoid masking the programming error.
+    """
+
+    pass

--- a/broker/helpers/misc.py
+++ b/broker/helpers/misc.py
@@ -167,6 +167,9 @@ def handle_keyboardinterrupt(*args):
         raise exceptions.BrokerError("Broker killed by user.")
     elif choice == "r":
         click.echo("Resuming execution...")
+        # Raise a special exception to signal that execution should resume
+        # This allows the calling code to retry the interrupted operation
+        raise exceptions.InterruptResumeError()
 
 
 def translate_timeout(timeout):

--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -593,6 +593,29 @@ class AnsibleTower(Provider):
                 hosts.append(vm_name)
         return list(set(hosts))
 
+    def _prompt_for_dangling_host_action(self, reason=None):
+        """Prompt user for action to take with a dangling host.
+
+        Handles keyboard interrupts with resume by retrying the prompt.
+
+        Returns:
+            str: User's choice ('c', 's', 'cA', or 'sA')
+        """
+        if reason:
+            logger.warning(f"Failure reason: {reason}")
+        # Retry prompt until we get a valid choice (handle keyboard interrupts with resume)
+        while True:
+            try:
+                return Prompt.ask(
+                    "What would you like to do with this host? [c/s/cA/sA]\n"
+                    "Checkin (c), Store (s), Checkin All (cA), Store All (sA)",
+                    choices=["c", "s", "cA", "sA"],
+                )
+            except exceptions.InterruptResumeError:  # noqa: PERF203
+                # If interrupted but user chose to resume, retry the prompt
+                # Exception handling in loop is intentional here to allow retry on resume
+                logger.debug("Prompt interrupted, retrying...")
+
     def handle_dangling_hosts(self, job, reason=None):
         """Attempt to check in dangling hosts associated with the given job."""
         dangling_hosts = self._try_get_dangling_hosts(job)
@@ -603,13 +626,7 @@ class AnsibleTower(Provider):
         for dangling_host in dangling_hosts:
             logger.warning(f"Found dangling host: {dangling_host}")
             if dangling_behavior == "prompt":
-                if reason:
-                    logger.warning(f"Failure reason: {reason}")
-                choice = Prompt.ask(
-                    "What would you like to do with this host? [c/s/cA/sA]\n"
-                    "Checkin (c), Store (s), Checkin All (cA), Store All (sA)",
-                    choices=["c", "s", "cA", "sA"],
-                )
+                choice = self._prompt_for_dangling_host_action(reason)
                 if choice == "cA":
                     dangling_behavior = "checkin"
                 elif choice == "sA":

--- a/tests/providers/test_ansible_tower.py
+++ b/tests/providers/test_ansible_tower.py
@@ -292,3 +292,36 @@ def test_host_creation_with_lazy_loaded_artifacts(tower_stub):
     assert host.hostname == "test-satellite-host.example.com"
     assert host.name == "test-satellite-stream-172-rhel9.7"
     assert host.host_type == "satellite"
+
+
+def test_prompt_for_dangling_host_action_with_interrupt_resume(tower_stub, monkeypatch):
+    """Test that _prompt_for_dangling_host_action retries when InterruptResumeError is raised.
+
+    This test verifies the fix for the issue where keyboard interrupts followed by
+    resume would leave the prompt in a confused state with validation errors.
+    """
+    from broker import exceptions
+
+    # Create a mock that raises InterruptResumeError once, then returns valid choice
+    call_count = 0
+
+    def mock_prompt_ask(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: simulate keyboard interrupt with resume
+            raise exceptions.InterruptResumeError()
+        else:
+            # Second call: return valid choice
+            return "c"
+
+    # Patch Prompt.ask to use our mock
+    monkeypatch.setattr("rich.prompt.Prompt.ask", mock_prompt_ask)
+
+    # Call the method - should retry after InterruptResumeError
+    result = tower_stub._prompt_for_dangling_host_action(reason="test reason")
+
+    # Verify it was called twice (once failed, once succeeded)
+    assert call_count == 2
+    # Verify it returned the valid choice from the second call
+    assert result == "c"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,55 @@
+"""Test file for broker.commands module helpers."""
+
+import pytest
+from broker.commands import _handle_ambiguous_names
+
+
+def test_handle_ambiguous_names_with_interrupt_resume(monkeypatch, capsys):
+    """Test that _handle_ambiguous_names retries prompt when InterruptResumeError is raised."""
+    from broker import exceptions
+    from broker.config_manager import ConfigManager
+
+    # Setup test data
+    filtered_scenarios = [
+        {"path": "scenario1.yaml"},
+        {"path": "scenario2.yaml"},
+    ]
+    name = "test"
+    category = None
+    import_all = False
+
+    # Enable interactive mode for this test
+    original_interactive = ConfigManager.interactive_mode
+    ConfigManager.interactive_mode = True
+
+    try:
+        # Track how many times the prompt is called
+        call_count = 0
+
+        def mock_prompt(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: simulate keyboard interrupt with resume
+                raise exceptions.InterruptResumeError()
+            else:
+                # Second call: user selects first scenario
+                return 1
+
+        # Patch both the module's click.prompt and the imported one in commands
+        monkeypatch.setattr("broker.commands.click.prompt", mock_prompt)
+
+        # Call the function - should retry after InterruptResumeError
+        result_scenarios, result_paths, should_continue = _handle_ambiguous_names(
+            filtered_scenarios, name, category, import_all
+        )
+
+        # Verify the prompt was called twice (once failed, once succeeded)
+        assert call_count == 2
+        # Verify the result is correct (first scenario selected)
+        assert len(result_scenarios) == 1
+        assert result_scenarios[0]["path"] == "scenario1.yaml"
+        assert should_continue is True
+    finally:
+        # Restore original interactive mode
+        ConfigManager.interactive_mode = original_interactive

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -64,3 +64,34 @@ def test_nicks(broker_settings_path):
     assert "test_nick" in nick_list
     test_nick = cfg_mgr.nicks("test_nick")
     assert test_nick == TEST_CFG_DATA["nicks"]["test_nick"]
+
+
+def test_init_config_file_with_interrupt_resume(broker_settings_path, monkeypatch):
+    """Test that init_config_file retries prompt when InterruptResumeError is raised."""
+    from broker import exceptions
+
+    # Create a config manager with existing settings file
+    cfg_mgr = ConfigManager(broker_settings_path)
+    cfg_mgr.interactive_mode = True
+
+    # Track how many times the prompt is called
+    call_count = 0
+
+    def mock_prompt(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: simulate keyboard interrupt with resume
+            raise exceptions.InterruptResumeError()
+        else:
+            # Second call: user chooses not to overwrite
+            return "n"
+
+    # Patch click.prompt to use our mock
+    monkeypatch.setattr("click.prompt", mock_prompt)
+
+    # Call init_config_file - should retry after InterruptResumeError
+    cfg_mgr.init_config_file()
+
+    # Verify the prompt was called twice (once failed, once succeeded)
+    assert call_count == 2


### PR DESCRIPTION
When a user pressed Ctrl+C during a prompt and chose to resume execution, the prompt would become stuck validating against the interrupt handler's options instead of the original prompt's options.

The signal handler now raises InterruptResumeError when resuming, allowing calling code to properly retry the interrupted prompt. Fixed three vulnerable prompts: dangling host action selection, config file overwrite confirmation, and scenario import selection.

Added test coverage for the interrupt resume behavior.