### PR TITLE
Add version and snap to broker inventory

### DIFF
--- a/broker/config_migrations/v0_6_0.py
+++ b/broker/config_migrations/v0_6_0.py
@@ -86,6 +86,8 @@ def add_inventory_fields(config_dict):
         "Provider": "_broker_provider",
         "Action": "$action",
         "OS": "os_distribution os_distribution_version",
+        "Version": "_broker_args.deploy_sat_version",
+        "Snap": "_broker_args.deploy_snap_version",
     }
     config_dict["inventory_list_vars"] = "hostname | name"
     return config_dict

--- a/broker/config_migrations/v0_8_10.py
+++ b/broker/config_migrations/v0_8_10.py
@@ -1,0 +1,28 @@
+"""Config migrations for versions older than 0.8.10 to 0.8.10."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+TO_VERSION = "0.8.10"
+
+
+def add_version_snap_inventory_fields(config_dict):
+    """Add Version and Snap to inventory_fields if not already present."""
+    inv_fields = config_dict.get("inventory_fields", {})
+    if "Version" not in inv_fields:
+        logger.debug("Adding Version to inventory_fields.")
+        inv_fields["Version"] = "_broker_args.deploy_sat_version"
+    if "Snap" not in inv_fields:
+        logger.debug("Adding Snap to inventory_fields.")
+        inv_fields["Snap"] = "_broker_args.deploy_snap_version"
+    config_dict["inventory_fields"] = inv_fields
+    return config_dict
+
+
+def run_migrations(config_dict):
+    """Run all migrations."""
+    logger.info(f"Running config migrations for {TO_VERSION}.")
+    config_dict = add_version_snap_inventory_fields(config_dict)
+    config_dict["_version"] = TO_VERSION
+    return config_dict

--- a/broker_settings.yaml.example
+++ b/broker_settings.yaml.example
@@ -13,6 +13,8 @@ inventory_fields:
   Provider: _broker_provider  # just pull the _broker_provider value
   Action: $action  # some special field values are possible, check the wiki
   OS: os_distribution os_distribution_version  # you can combine multiple values with a space between
+  Version: _broker_args.deploy_sat_version
+  Snap: _broker_args.deploy_snap_version
 # Much like you can set a variable lookup order for inventory fields
 inventory_list_vars: hostname | name | ip
 # Optionally set a limit for the number of threads Broker can use for actions


### PR DESCRIPTION
Okay here me out... I checkout A LOT of VMs lol, and I hate having to scroll through them all looking for my satellite version and snap number. I know we can individually add this into our broker settings but I would like to propose adding this into our defaults.

*This is a feature for satellite vms. Hosts currently show "unknown" in both the Version and Snap field.*

what do you think? @JacobCallahan  