### PR TITLE
Refactor loader removal for dynaconf version changes

### DIFF
--- a/broker/settings.py
+++ b/broker/settings.py
@@ -102,9 +102,17 @@ def _create_and_configure_settings(file_path, file_exists, config_dict):
     )
 
     # Remove vault loader if set somehow
-    new_settings.__core__.config.loaders = [
-        loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader
-    ]
+    # In dynaconf 3.2.0+, __core__ was removed. Use _loaders directly instead.                                                                                              
+    if hasattr(new_settings, '__core__'):                                                                                                                                   
+        # dynaconf < 3.2.0                                                                                                                                                  
+        new_settings.__core__.config.loaders = [                                                                                                                            
+            loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader                                                                                 
+        ]                                                                                                                                                                   
+    else:                                                                                                                                                                   
+        # dynaconf >= 3.2.0                                                                                                                                                 
+        new_settings._loaders = [                                                                                                                                           
+            loader for loader in new_settings._loaders if "vault" not in loader                                                                                             
+        ]          
 
     # Add any configuration values passed in, merging nested dicts
     if config_dict:

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -102,17 +102,17 @@ def _create_and_configure_settings(file_path, file_exists, config_dict):
     )
 
     # Remove vault loader if set somehow
-    # In dynaconf 3.2.0+, __core__ was removed. Use _loaders directly instead.                                                                                              
-    if hasattr(new_settings, '__core__'):                                                                                                                                   
-        # dynaconf < 3.2.0                                                                                                                                                  
-        new_settings.__core__.config.loaders = [                                                                                                                            
-            loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader                                                                                 
-        ]                                                                                                                                                                   
-    else:                                                                                                                                                                   
-        # dynaconf >= 3.2.0                                                                                                                                                 
-        new_settings._loaders = [                                                                                                                                           
-            loader for loader in new_settings._loaders if "vault" not in loader                                                                                             
-        ]          
+    # In dynaconf 3.2.0+, __core__ was removed. Use _loaders directly instead.
+    if hasattr(new_settings, "__core__"):
+        # dynaconf < 3.2.0
+        new_settings.__core__.config.loaders = [
+            loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader
+        ]
+    else:
+        # dynaconf >= 3.2.0
+        new_settings._loaders = [
+            loader for loader in new_settings._loaders if "vault" not in loader
+        ]
 
     # Add any configuration values passed in, merging nested dicts
     if config_dict:

--- a/broker/settings.py
+++ b/broker/settings.py
@@ -102,17 +102,14 @@ def _create_and_configure_settings(file_path, file_exists, config_dict):
     )
 
     # Remove vault loader if set somehow
-    # In dynaconf 3.2.0+, __core__ was removed. Use _loaders directly instead.
+    # In dynaconf >= 3.3.0, settings exposes `__core__`; older versions rely on `_loaders`.
+    filtered_loaders = [
+        loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader
+    ]
     if hasattr(new_settings, "__core__"):
-        # dynaconf < 3.2.0
-        new_settings.__core__.config.loaders = [
-            loader for loader in new_settings.loaders_for_dynaconf if "vault" not in loader
-        ]
+        new_settings.__core__.config.loaders = filtered_loaders
     else:
-        # dynaconf >= 3.2.0
-        new_settings._loaders = [
-            loader for loader in new_settings._loaders if "vault" not in loader
-        ]
+        new_settings._loaders = filtered_loaders
 
     # Add any configuration values passed in, merging nested dicts
     if config_dict:


### PR DESCRIPTION
after broker update I got an issue when running broker execute, `AttributeError: 'Settings' object has no attribute '__CORE__'`, claude suggested this, and it works for me to mitigate the issue. But obviously, feel free to close this in favor of proper solution

Fixes #526