### PR TITLE
Catch host not found exceptions when compiling host info from AnsibleTower

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -651,7 +651,7 @@ class AnsibleTower(Provider):
     def _compile_host_info(self, host):
         try:
             host_facts = host.related.ansible_facts.get()
-        except awxkit.exceptions.Forbidden as err:
+        except (awxkit.exceptions.Forbidden, awxkit.exceptions.NotFound) as err:
             logger.warning(f"Unable to get facts for {host.name}: {err}")
             host_facts = {}
 


### PR DESCRIPTION
If a user's inventory is large enough and enough time passes during an inventory sync between when broker gets the initial host list and when it fetches a host's details, that host might have diseappeared from the Ansible Tower / AAP provider. That results in an uncaught exception in `_compile_host_info`:

```
$ broker inventory --sync AnsibleTower
17Jul 15:54:46 INFO     Pulling remote inventory from AnsibleTower
Compiling host information ━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  18% 0:02:22
17Jul 15:55:21 ERROR    BrokerError: Not Found (404) received - {'detail': 'No Host matches the given query.'}
               ERROR    Command failed: Not Found (404) received - {'detail': 'No Host matches the given query.'}
Command failed: Not Found (404) received - {'detail': 'No Host matches the given query.'}
```

This PR updates `_compile_host_info` to catch those exceptions, so that the inventory sync can finish successfully. The missing hosts will not be included in the resulting local inventory.

```
$ broker inventory --sync AnsibleTower
17Jul 15:28:09 INFO     Pulling remote inventory from AnsibleTower
17Jul 15:29:06 WARNING  Unable to get facts for <HOST_A>: Not Found (404) received - {'detail': 'No Host matches the given query.'}            
17Jul 15:29:23 WARNING  Unable to get facts for <HOST_B>: Not Found (404) received - {'detail': 'No Host matches the given query.'}            
[...]
Compiling host information ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:02:33
                                            Host Inventory                                            
┏━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Id ┃ Hostname      ┃ Name                               ┃ Info    ┃
┡━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ 0  │ <HOSTNAME_C>  │ <HOST_C>                           │ Unknown │
└────┴────────────── ┴────────────────────────────────────┴─────────┘
```