### PR TITLE
Deep copy mutable values in Host.to_dict()

### DIFF
--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -214,10 +214,13 @@ class Host:
         }
         if prov_inst := getattr(self, "_prov_inst", None):
             ret_dict["_broker_provider_instance"] = prov_inst.instance
-        ret_dict.update({
-            k: copy.deepcopy(v) if isinstance(v, (list, dict)) else v
-            for k, v in self.__dict__.items() if k in self.keep_keys
-        })
+        ret_dict.update(
+            {
+                k: copy.deepcopy(v) if isinstance(v, (list, dict)) else v
+                for k, v in self.__dict__.items()
+                if k in self.keep_keys
+            }
+        )
         return ret_dict
 
     def setup(self):

--- a/broker/hosts.py
+++ b/broker/hosts.py
@@ -15,6 +15,7 @@ Usage:
     ```
 """
 
+import copy
 import logging
 
 from broker.exceptions import HostError, NotImplementedError
@@ -213,7 +214,10 @@ class Host:
         }
         if prov_inst := getattr(self, "_prov_inst", None):
             ret_dict["_broker_provider_instance"] = prov_inst.instance
-        ret_dict.update({k: v for k, v in self.__dict__.items() if k in self.keep_keys})
+        ret_dict.update({
+            k: copy.deepcopy(v) if isinstance(v, (list, dict)) else v
+            for k, v in self.__dict__.items() if k in self.keep_keys
+        })
         return ret_dict
 
     def setup(self):


### PR DESCRIPTION
## Problem

Mutable fields (`list`, `dict`) included in `keep_keys` are copied by reference in `to_dict()`. When a host is reconstructed via `from_dict()`, both instances share the same underlying objects — so in-place mutation on one silently affects the other:

```python
h2 = Host.from_dict(h1.to_dict())

h2.reported_devices.append("eth1")
print(h1.reported_devices)  # ["eth1"] — unintended, shared reference
```

Reassignment is safe, but in-place mutation is not:
```python
h2.reported_devices = ["eth1"]  # only affects h2 — fine
```

## Fix

Selectively `deepcopy` values that are `list` or `dict` when building the `keep_keys` portion of the dict. Primitive values (strings, ints) are left as-is to avoid unnecessary overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)