### PR TITLE
Overwrite compute attributes

### DIFF
--- a/broker/helpers/inventory.py
+++ b/broker/helpers/inventory.py
@@ -49,8 +49,16 @@ def update_inventory(add=None, remove=None):
 
     :return: no return value
     """
+    from dynaconf.utils.boxing import DynaBox
+
     from broker.helpers.file_utils import FileLock
     from broker.settings import inventory_path
+
+    # Configure ruamel yaml representer for Dynabox
+    yaml.representer.add_representer(
+        DynaBox,
+        lambda dumper, data: dumper.represent_dict(dict(data)),
+    )
 
     if add and not isinstance(add, list):
         add = [add]

--- a/broker/providers/foreman.py
+++ b/broker/providers/foreman.py
@@ -283,7 +283,8 @@ class Foreman(Provider):
 
         host["hostgroup_id"] = self.runtime.obtain_id_from_name("hostgroups", hostgroup)
         host["build"] = True
-        host["compute_attributes"] = {"start": "1"}
+        if "compute_attributes" not in host:
+            host["compute_attributes"] = {"start": "1"}
         host["organization_id"] = self.organization_id
         host["location_id"] = self.location_id
 


### PR DESCRIPTION
We recently started using the broker provider `foreman` for deploying both to vmware as well as proxmox. Compute attributes differ. This PR allows to adjust them but continues providing suitable values for provisioning to VMware.

For this specific case we needed to pass structured data:

```
compute_attributes:
  node_id: <our hypervisor>
  start_after_create: 1
```

The second commit allows to find a correct representation in the inventory.