### PR TITLE
Implement pagination and optimization for Ansible Tower inventory retrieval

### DIFF
--- a/broker/providers/ansible_tower.py
+++ b/broker/providers/ansible_tower.py
@@ -944,11 +944,24 @@ class AnsibleTower(Provider):
     def get_inventory(self, user=None):
         """Compile a list of hosts based on any inventory a user's name is mentioned."""
         user = user or self.username
-        invs = [
-            inv
-            for inv in self._v2.inventory.get(page_size=200).results
-            if user in inv.name or user == "@ll"
-        ]
+        invs = []
+        page = 1
+
+        while page_invs := self._v2.inventory.get(page_size=100, page=page).results:
+            for inv in page_invs:
+                if user in inv.name or user == "@ll":
+                    invs.append(inv)  # noqa: PERF401
+
+            # Stop early if we found user inventory and not syncing all
+            if invs and user != "@ll":
+                break
+
+            # Check if there are more results
+            if len(page_invs) < 100:  # noqa: PLR2004
+                break
+
+            page += 1
+
         hosts = []
         for inv in invs:
             inv_hosts = inv.get_related("hosts", page_size=200).results


### PR DESCRIPTION
Features:
- Added pagination support to inventory fetching to ensure all inventories are scanned, removing previous limits on the number of results processed.

Fixes:
- Resolved a potential issue where user inventories beyond the first page of results would not be discovered.

Refactoring:
- Optimized the retrieval process to terminate the pagination loop early once a user-specific inventory is found, reducing unnecessary API calls.
- Updated the inventory filtering logic to use a page-by-page iterative approach with a standard page size of 100.